### PR TITLE
feat!: id-only book queues, OrderPool, optional rayon, docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing
+
+## Engineering process
+
+1. **Issue** — describe the behavior, constraints, and acceptance checks.
+2. **Branch** — `feat/…`, `fix/…`, `docs/…`, aligned with the issue.
+3. **Incremental commits** — small, reviewable steps; [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `test:`, `chore:`).
+4. **Quality gates** — locally match CI: `make ci`, and `make quality-gate` if `pmat` is installed (see `Makefile` for the default check set; extend with `--include-provability` or `--checks dead-code,entropy` when tightening ITCH/harness coverage).
+5. **Pull request** — link the issue, summarize behavior change, note benches or perf impact.
+6. **Review & verification** — CI green, coverage budget respected; maintainer merge after sign-off.
+
+## Optional / extended verification
+
+- **Proptest** — `cargo test -p omer proptest_store_roundtrip` (see `tests/proptest_store_roundtrip.rs`).
+- **Mutation testing** — `cargo install cargo-mutants` then `cargo mutants -- --all-features` (slow; run before risky refactors).
+- **Fuzzing** — add `cargo-fuzz` targets when parsing or binary protocols change materially.
+- **Kani** — for small pure functions, consider [Kani](https://model-checking.github.io/kani/) (`cargo install kani-verifier && cargo kani -p omer`); not required for every PR.
+
+## Code style
+
+- `cargo fmt --all`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- No `unsafe` without explicit `// SAFETY:` and review (crate default is `forbid`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,10 +274,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -320,14 +357,26 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
- "rand_core",
+ "r-efi 6.0.0",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -432,6 +481,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,8 +550,10 @@ dependencies = [
  "crossbeam-skiplist",
  "dashmap",
  "mockall",
+ "proptest",
  "quickcheck",
  "quickcheck_macros",
+ "rayon",
  "rstest",
  "thiserror",
 ]
@@ -571,6 +628,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "predicates"
 version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -625,6 +691,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quickcheck"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,7 +723,7 @@ checksum = "95c589f335db0f6aaa168a7cd27b1fc6920f5e1470c804f814d9cd6e62a0f70b"
 dependencies = [
  "env_logger",
  "log",
- "rand",
+ "rand 0.10.0",
 ]
 
 [[package]]
@@ -657,9 +748,25 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rand"
@@ -667,8 +774,27 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
- "getrandom",
- "rand_core",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -676,6 +802,15 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rayon"
@@ -780,10 +915,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "same-file"
@@ -879,6 +1039,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -945,6 +1118,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -955,6 +1134,15 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,13 @@ categories = ["network", "messaging", "communication"]
 [dependencies]
 crossbeam-skiplist = "0.1"
 dashmap = "6"
+rayon = { version = "1.10", optional = true }
 thiserror = "2.0"
 
 [features]
 default = ["harness"]
 harness = []
+parallel = ["dep:rayon"]
 
 [lints.rust]
 unsafe_code = "forbid"
@@ -30,6 +32,7 @@ criterion = "0.8"
 mockall = "0.14"
 quickcheck = "1.0"
 quickcheck_macros = "1.1"
+proptest = "1.6"
 rstest = "0.26"
 
 [[bench]]

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 CARGO ?= cargo
 MAKE ?= make
 
-.PHONY: check fmt fmt-check clippy test deny doc machete ci cov-info
+.PHONY: check fmt fmt-check clippy test deny doc machete ci cov-info quality-gate
 
 check:
 	$(CARGO) check --all-features --all-targets
@@ -18,7 +18,7 @@ clippy:
 	$(CARGO) clippy --all-features --all-targets -- -D warnings
 
 test:
-	$(CARGO) test --all-features --all-targets
+	$(CARGO) test --workspace --all-features --all-targets
 
 doc:
 	$(CARGO) doc --all-features --no-deps
@@ -43,3 +43,14 @@ ci:
 	$(MAKE) doc
 	$(MAKE) deny
 	$(MAKE) machete
+
+# Optional: install `pmat` (`cargo install pmat`). Default checks avoid noisy per-file dead-code
+# and entropy heuristics on generated-style ITCH helpers; extend locally as needed.
+PMAT_CHECKS ?= complexity,satd,security,duplicates,sections
+quality-gate:
+	@if command -v pmat >/dev/null 2>&1; then \
+		pmat quality-gate --project-path . --fail-on-violation --checks $(PMAT_CHECKS); \
+	else \
+		echo "pmat not installed; skipping (cargo install pmat)"; \
+		exit 0; \
+	fi

--- a/README.md
+++ b/README.md
@@ -2,192 +2,139 @@
 
 [![CI](https://github.com/vvylym/order-matching-engine/actions/workflows/ci.yml/badge.svg)](https://github.com/vvylym/order-matching-engine/actions/workflows/ci.yml)
 
-Rust library that matches **limit and market orders** against a **price–time** book: add, cancel, replace, and related commands go through one **`OrderMatchingEngine`** type. Numbers are integers (ticks / lots); there is no `f64` on the hot path.
+Rust library: **limit/market** matching on a **price–time** book. Commands (`add`, `cancel`, `replace`, …) go through **`OrderMatchingEngine`**. Numeric fields use integers (ticks / lots); no `f64` on the hot path.
 
-**Repository:** [github.com/vvylym/order-matching-engine](https://github.com/vvylym/order-matching-engine)  
-**Crate name on crates.io:** `omer` (same as the package in `Cargo.toml`).
-
-If **GitHub’s README looks stale**, compare the **commit on `main`** to your local tree — the default branch only changes after a **push** (or merged PR).
+**Repo:** [github.com/vvylym/order-matching-engine](https://github.com/vvylym/order-matching-engine) · **crate:** `omer`
 
 ---
 
-## Performance roadmap (matching hot path → 1B+ ops/s in-process)
+## Installation
 
-Roadmap for **CPU-bound** add/cancel/match work (no sockets). **1B+ ops/s** here means the **matcher + book** sustaining that aggregate rate on suitable hardware (many cores, batching, sharding — see Phase 4), not a single `localhost` TCP loop.
+Add to your `Cargo.toml`:
 
-### Phase 1 (week 1–2) — book structure + first throughput band
+```toml
+[dependencies]
+omer = "0.1"
+```
 
-- [x] Add **`dashmap`** dependency  
-- [x] Per-side book: **`DashMap<Price, Vec<Order>>`** for level queues + **`SkipMap<Price, ()>`** for best bid / best ask  
-- [x] **`DashSkipOrderBook`** in [`src/book/service/dash_skip.rs`](src/book/service/dash_skip.rs) (implements [`PriceBook`](src/book/mod.rs))  
-- [x] Benchmark **`throughput_book`** — target **~200–300M pushes/sec** on strong CPUs (run locally; record CPU + `rustc -V`)  
-- [x] **`latency_add`** compares **InMemory**, **BTree**, **PoolLevel**, **DashSkip** behind the same harness ([`benches/latency_add.rs`](benches/latency_add.rs))  
+Optional: **`parallel`** (pulls in `rayon` for read-mostly helpers):
 
-### Phase 2 (week 2–3) — pooling + parallel batches
+```toml
+omer = { version = "0.1", features = ["parallel"] }
+```
 
-- [ ] **`OrderPool`** / arena for resting `Order` payloads (reduce `clone` pressure on book levels)  
-- [x] **Batch API:** [`OrderMatchingEngine::process_batch`](src/engine/service.rs) (`OrderCommand` iterator; commits in order, stops on first error)  
-- [ ] **`rayon`** (optional feature) for **sharded** or read-mostly paths — single-writer book stays serial  
-- [x] Engine throughput bench **[`throughput_engine`](benches/throughput_engine.rs)** — warm book + **`process_batch`** of 512 resting adds, **four** `PriceBook` backends, **`NoOpEventSink`**; local target band **~300–500M adds/sec** class on big cores (measure; not CI-gated)  
+Omit default harness for library-only use:
 
-### Phase 3 (week 3–4) — order-type specialization
-
-- [x] Rich **`Order`** / TIF types (already in crate)  
-- [ ] **`OrderBehavior`**, trait-based or enum-dispatched fast paths per order type  
-- [ ] Benches **per order type**; **no regression** vs baseline commits  
-
-### Phase 4 (week 4–5) — sharding + micro-architecture
-
-- [ ] **`ShardedOrderBook`** (partition by price / symbol)  
-- [ ] **SIMD** helpers where profiling proves they win  
-- [ ] **CPU affinity** / pinning notes or cfg for deployment  
-- [ ] Benchmark band **~500M–1B+ ops/sec** aggregate in-process; **perf / flamegraph** workflow documented in this README (see **Profiling**); backlog in [`benches/PLAN.md`](benches/PLAN.md)  
+```toml
+omer = { version = "0.1", default-features = false }
+```
 
 ---
 
-## What you get today
+## Usage
 
-| Area | Status |
-|------|--------|
-| **Matching** | Single-symbol engine: limit/market, partial fills, IOC/GTC and related TIF, replace, cancel-by-id, reduce, execute (see `OrderCommand` in [`src/engine/models.rs`](src/engine/models.rs)). |
-| **Storage / book** | **`PriceBook`** + **`OrderStore`**: `BTreeOrderBook`, **`DashSkipOrderBook`** (DashMap + SkipMap, Phase 1), `PoolLevelOrderBook`, `dense` / `hash_map` stores. |
-| **ITCH** | NASDAQ ITCH-style **binary messages** can be read from a stream and turned into engine commands (`src/itch/`). |
-| **Tests** | Integration tests under [`tests/`](tests/) (semantics, replay, self-trade, stress/property checks). CI runs them on every push/PR. |
-| **Coverage** | CI fails if **line** coverage (llvm-cov) falls **below 85%** — see [`scripts/coverage.sh`](scripts/coverage.sh). |
+```rust
+use omer::engine::{OrderMatchingService, OrderCommand};
+use omer::harness::{add_cmd, engine_with_memory};
+use omer::types::{OrderType, Side, TimeInForce};
+
+let (mut engine, _sink) = engine_with_memory();
+let cmd = OrderCommand::Add(add_cmd(
+    1,
+    100,
+    Side::Buy,
+    OrderType::Limit,
+    Some(50),
+    10,
+    TimeInForce::Gtc,
+));
+engine.process(cmd).expect("accepted");
+```
+
+See [`tests/`](tests/) and [`src/engine/models.rs`](src/engine/models.rs) for the full command set.
 
 ---
 
-## Requirements
+## Repository layout
 
-- **Rust:** stable toolchain (same as CI; edition 2024 in `Cargo.toml`).
-- **Optional:** [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov) locally to match the coverage job.
+| Path | Role |
+|------|------|
+| [`src/lib.rs`](src/lib.rs) | Crate root; module overview |
+| [`src/types.rs`](src/types.rs) | `Order`, `Price`, `Quantity`, sides, TIF |
+| [`src/engine/`](src/engine/) | `OrderMatchingService`, `OrderMatchingEngine`, commands |
+| [`src/book/`](src/book/) | [`PriceBook`](src/book/mod.rs) trait + implementations |
+| [`src/store/`](src/store/) | [`OrderStore`](src/store/mod.rs) trait + implementations |
+| [`src/events/`](src/events/) | `Event`, `EventSink`, `NoOpEventSink` |
+| [`src/matching/`](src/matching/), [`src/self_trade/`](src/self_trade/), [`src/sequence/`](src/sequence/) | Policies and sequence generation |
+| [`src/itch/`](src/itch/) | ITCH-style decode + streaming entry points |
+| [`src/pool/`](src/pool/mod.rs) | `OrderPool` (reuse `Order` shells outside the engine) |
+| [`src/parallel.rs`](src/parallel.rs) | Optional `rayon` helper for read-mostly aggregation (feature **`parallel`**) |
+| [`src/harness/`](src/harness/) | Default test/bench wiring (feature **`harness`**, on by default) |
+| [`benches/`](benches/) | Criterion targets (`--no-run` in CI) |
+| [`tests/`](tests/) | Integration and property tests |
+
+Disable harness: `omer = { version = "…", default-features = false }`.
+
+---
+
+## Services (traits) and implementations
+
+| Service | Trait | Concrete types |
+|---------|--------|----------------|
+| Matching entrypoint | [`OrderMatchingService`](src/engine/service.rs) | [`OrderMatchingEngine`](src/engine/service.rs) |
+| Resting book | [`PriceBook`](src/book/mod.rs) | [`BTreeOrderBook`](src/book/service/btree.rs), [`PoolLevelOrderBook`](src/book/service/pool_level.rs), [`DashSkipOrderBook`](src/book/service/dash_skip.rs), [`InMemoryPriceBook`](src/harness/memory.rs) (harness) |
+| Order storage | [`OrderStore`](src/store/mod.rs) | [`HashMapOrderStore`](src/store/service/hash_map.rs), [`DenseOrderStore`](src/store/service/dense.rs), [`InMemoryOrderStore`](src/harness/memory.rs) |
+
+**Resting layout (important):** the book keeps **`OrderId` queues per price**; the **canonical [`Order`] payload** lives only in **`OrderStore`**. `PriceBook::push` takes `order_id`, `side`, and a **`time_priority`** (`Sequence`) so the in-memory test book can respect time priority; FIFO backends ignore that field.
+
+**Pooling:** [`OrderPool`](src/pool/mod.rs) recycles `Order` structs for adapters and gateways (not required for core matching).
+
+**Parallel reads:** enable `parallel` and use [`parallel::par_best_quotes`](src/parallel.rs) to aggregate best bid/ask over many books in parallel; matching remains single-writer per book.
+
+---
+
+## Benchmarks (what they measure)
+
+| Bench | Command | What it does |
+|-------|---------|----------------|
+| `throughput_engine` | `cargo bench -p omer --bench throughput_engine` | Warm book + `process_batch` (512 GTC buys), **four** `PriceBook` backends, `NoOpEventSink` |
+| `latency_add` | `cargo bench -p omer --bench latency_add` | One resting `add` per iteration, same four backends, collecting sink |
+| `throughput_book` | `cargo bench -p omer --bench throughput_book` | `DashSkipOrderBook::push` only (ids; no engine) |
+| `itch_parse` | `cargo bench -p omer --bench itch_parse` | `scan_decode_book_messages` on AddOrder buffer |
+| `micro`, `matching_engine`, `market_manager` | same pattern | Smoke / placeholder loops; see [`benches/PLAN.md`](benches/PLAN.md) |
+
+CI compiles all benches with `cargo bench --no-run --workspace --all-features` but does not report Criterion output.
+
+---
+
+## Profiling (engine hot path)
+
+Release build, pinned CPU, frame pointers:
+
+```bash
+export RUSTFLAGS="-C force-frame-pointers=yes"
+cargo flamegraph --bench throughput_engine --features harness -- --bench
+```
+
+Alternatives: `perf record` + flame graph tooling (see earlier commits or team runbooks). Attach machine type, `rustc -V`, and git SHA with any numbers.
 
 ---
 
 ## Quick start
 
-Clone the repo, then from the crate root:
-
 ```bash
 cargo test --all-features --all-targets
-```
-
-Run the linter the same way CI does:
-
-```bash
 cargo clippy --workspace --all-targets --all-features -- -D warnings
-```
-
-CI also runs **`cargo fmt --all -- --check`**. Format before pushing:
-
-```bash
 cargo fmt --all
 ```
 
-Line coverage (after installing `cargo-llvm-cov`):
-
-```bash
-chmod +x scripts/coverage.sh
-./scripts/coverage.sh
-```
+Coverage (optional): [`scripts/coverage.sh`](scripts/coverage.sh) (CI enforces line coverage threshold).
 
 ---
 
-## How the crate is organized
+## Contributing and quality gates
 
-Read top-down:
-
-1. **[`src/lib.rs`](src/lib.rs)** — short overview of modules (crate docs).
-2. **[`src/engine/`](src/engine/)** — **`OrderMatchingService`** trait and **`OrderMatchingEngine`** implementation.
-3. **[`src/types.rs`](src/types.rs)** — **`Order`**, prices, quantities, sides, TIF.
-4. **`src/book/`, `src/store/`** — traits plus concrete services.
-5. **`src/itch/`** — wire layout + streaming entry points.
-6. **`src/harness/`** (feature **`harness`**, **on by default**) — shared store, policies, and event sink; pick the book with **`engine_with_book`** / **`engine_with_*`**. Use **`engine_with_book_noop`** when benchmarks must not allocate on **`Event::Accepted`**. Omit harness: `omer = { version = "…", default-features = false }`.
-
----
-
-## Benchmarks and performance (today)
-
-| Bench | What it does right now |
-|-------|-------------------------|
-| **`latency_add`** | Same harness, **four `PriceBook` backends** (in-memory B-tree levels, `BTreeOrderBook`, `PoolLevelOrderBook`, `DashSkipOrderBook`): one resting buy `add` per iter. Run: `cargo bench -p omer --bench latency_add`. |
-| **`throughput_book`** | **`PriceBook::push`** on **`DashSkipOrderBook`**: same-price FIFO vs distinct-price levels (50k ops/iter). Run: `cargo bench -p omer --bench throughput_book`. |
-| **`throughput_engine`** | Warmed engine + **`process_batch`** (512 resting limit buys), **four** book backends, **`NoOpEventSink`**. Run: `cargo bench -p omer --bench throughput_engine`. |
-| **`itch_parse`** | **`scan_decode_book_messages`** on a buffer of **AddOrder** packets (decode only). Run: `cargo bench -p omer --bench itch_parse`. |
-| **`micro`**, **`market_manager`**, **`matching_engine`** | **Placeholder** loops so `cargo bench --no-run` keeps targets building; see [`benches/PLAN.md`](benches/PLAN.md). |
-
-### Benchmark methodology (engine vs book)
-
-| Target | Bench | Notes |
-|--------|--------|--------|
-| **End-to-end add + book + store** (no event alloc) | [`throughput_engine`](benches/throughput_engine.rs) | 4096-order warm-up, then **`process_batch`** of **512** GTC limit buys per sample; **`NoOpEventSink`**. Compare **`inmemory_price_book`**, **`btree_order_book`**, **`pool_level_book`**, **`dash_skip_book`**. |
-| **Single `add` latency** | [`latency_add`](benches/latency_add.rs) | Same four backends; **`CollectingEventSink`**. |
-| **Raw push into book** | [`throughput_book`](benches/throughput_book.rs) | **`DashSkipOrderBook::push` only** (no engine). |
-| **ITCH decode only** | [`itch_parse`](benches/itch_parse.rs) | **`scan_decode_book_messages`** on AddOrder buffer. |
-
-**Fastest engine implementation (today):** run the throughput bench and compare the four lines under **`throughput_engine_hot_batch`**. On typical Linux/x86_64 servers we expect **`dash_skip_book`** or **`pool_level_book`** to lead for batched resting adds—**your CPU and `rustc` version decide**. Treat **`DashSkipOrderBook`** as the primary **Phase 1** structure for sustained engine throughput until sharding lands; re-check after every book change.
-
-**North star:** **10⁹+ in-process operations per second** on the **matcher + book** path is a **program target** (sharding, batching, SIMD, cores — Phase 4), not something a single-threaded integration test proves. Network I/O is out of scope for that number: measure **decode**, **book/engine**, and (later) **gateway** separately. Always record hardware and `rustc` with published figures.
-
-**Pull request CI** compiles all benches but **does not** run long or distributed load tests (keeps feedback fast). If you run heavy benchmarks locally, record machine, git revision, and command in the PR text when you report numbers.
-
-**Safety:** `unsafe` is **forbidden** at crate level unless a future change adds a **small**, reviewed block with an explicit `// SAFETY:` note.
-
----
-
-### Profiling with `perf` and flamegraph (fastest engine backend)
-
-Use **release** builds and **one pinned CPU** so numbers are stable. Profile the binary that exercises the winning backend from **`throughput_engine`** (below we use the **`throughput_engine`** bench; pick **`dash_skip_book`** once confirmed on your machine).
-
-**1. Dependencies (Debian/Ubuntu examples)**
-
-```bash
-sudo apt install linux-tools-common linux-tools-$(uname -r)  # perf
-cargo install flamegraph   # optional; wraps perf + stack collapse
-```
-
-**2. Frame pointers (clearer stacks)**
-
-```bash
-export RUSTFLAGS="-C force-frame-pointers=yes"
-```
-
-**3. Option A — `cargo flamegraph` (simplest)**
-
-From the crate root:
-
-```bash
-cargo flamegraph --bench throughput_engine -- \
-  --bench
-```
-
-Open `flamegraph.svg` in a browser. You should see hot frames in **`process_batch` → `add` → `match_and_commit_incoming` → `PriceBook::push`** and related book/store paths.
-
-**4. Option B — `perf` record + `inferno-flamegraph` (manual)**
-
-```bash
-cargo build --release --bench throughput_engine
-# The exact binary name includes a hash; use tab completion:
-PERF=/usr/lib/linux-tools/$(uname -r)/perf   # adjust if perf lives elsewhere
-$PERF record -F 997 -g --call-graph dwarf -- \
-  target/release/deps/throughput_engine-* --bench
-$PERF script | inferno-collapse-perf | inferno-flamegraph > engine.svg
-```
-
-**5. Good practices**
-
-- Run **`echo performance \| sudo tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor`** only if you control the host and want stable frequency.
-- Pin the process: **`taskset -c 0 cargo flamegraph ...`**.
-- For **LBR** or **Intel PT**, use vendor-specific `perf` guides; dwarf stacks above work on most CI-like VMs.
-- Attach **`perf report -g graph`** screenshots or **`engine.svg`** to perf PRs when claiming regressions or wins.
-
-See [`benches/PLAN.md`](benches/PLAN.md) for the long-term bench backlog; this section is the **operational** recipe for the current fastest **`PriceBook` + engine** combo.
-
----
-
-## Contributing
-
-Issues and PRs are welcome. Match **existing style** (formatting, `clippy -D warnings`, tests). Use **conventional commits** if you can (`feat:`, `fix:`, `docs:`, …). For larger changes, open an issue first so direction matches maintainers’ expectations.
+See [`CONTRIBUTING.md`](CONTRIBUTING.md): **issue → branch → incremental commits → PR → review**. Use `make ci` to mirror CI and `make quality-gate` for the default [`pmat`](https://crates.io/crates/pmat) profile.
 
 ---
 

--- a/benches/throughput_book.rs
+++ b/benches/throughput_book.rs
@@ -1,8 +1,7 @@
-//! Throughput: [`PriceBook::push`] on [`omer::book::service::DashSkipOrderBook`]
-//! (Phase 1 — [`dashmap`] + [`crossbeam_skiplist`]).
+//! Throughput: [`PriceBook::push`] (order id + side + sequence only; no `Order` clone) on
+//! [`omer::book::service::DashSkipOrderBook`] ([`dashmap`] + [`crossbeam_skiplist`]).
 //!
-//! Local target band (single thread, no matching engine): **~200–300M pushes/sec** on strong
-//! desktop/server CPUs — verify on your machine; report CPU model and `rustc -V`.
+//! Record results with CPU model and `rustc -V`; CI only compiles benches (`cargo bench --no-run`).
 //!
 //! [`dashmap`]: https://docs.rs/dashmap
 //! [`crossbeam_skiplist`]: https://docs.rs/crossbeam-skiplist
@@ -10,29 +9,8 @@
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 use omer::book::PriceBook;
 use omer::book::service::DashSkipOrderBook;
-use omer::types::{Order, OrderId, OrderType, Side, TimeInForce};
+use omer::types::Side;
 use std::hint::black_box;
-
-fn mk_order(id: OrderId, side: Side, price: i64, qty: i64) -> Order {
-    Order {
-        symbol_id: 0,
-        id,
-        participant_id: 0,
-        side,
-        order_type: OrderType::Limit,
-        price: Some(price),
-        quantity: qty,
-        time_in_force: TimeInForce::Gtc,
-        stop_price: None,
-        max_visible_quantity: None,
-        slippage: None,
-        trailing_distance: None,
-        trailing_step: None,
-        executed_quantity: 0,
-        leaves_quantity: qty,
-        sequence: id,
-    }
-}
 
 const N: u64 = 50_000;
 
@@ -44,8 +22,7 @@ fn throughput_push(c: &mut Criterion) {
         b.iter(|| {
             let mut book = DashSkipOrderBook::new();
             for i in 0..N {
-                let o = mk_order(i, Side::Buy, 100, 1);
-                book.push(&100, &o);
+                book.push(&100, i, Side::Buy, i);
             }
             black_box(book.best_bid());
         });
@@ -56,8 +33,7 @@ fn throughput_push(c: &mut Criterion) {
             let mut book = DashSkipOrderBook::new();
             for i in 0..N {
                 let p = 100 + i as i64;
-                let o = mk_order(i, Side::Buy, p, 1);
-                book.push(&p, &o);
+                book.push(&p, i, Side::Buy, i);
             }
             black_box(book.best_bid());
         });

--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -6,7 +6,7 @@ pub mod service;
 #[cfg(test)]
 use mockall::automock;
 
-use crate::types::{Order, OrderId, Price, Side};
+use crate::types::{OrderId, Price, Sequence, Side};
 
 /// Price book trait
 #[cfg_attr(test, automock)]
@@ -15,12 +15,19 @@ pub trait PriceBook {
     fn best_bid(&self) -> Option<Price>;
     /// Get the best ask price
     fn best_ask(&self) -> Option<Price>;
-    /// Push an order to the price book
-    fn push(&mut self, price: &Price, order: &Order);
-    /// Pop the best resting order **on the opposite side** to `side` (the **aggressor** side):
+    /// Queue `order_id` at `price` on `side`. Canonical [`crate::types::Order`] must already live in [`crate::store::OrderStore`].
+    /// `time_priority` is the order's sequence (FIFO backends ignore it; in-memory test book uses it to order the level).
+    fn push(
+        &mut self,
+        price: &Price,
+        order_id: OrderId,
+        side: Side,
+        time_priority: Sequence,
+    );
+    /// Pop the best resting **order id** on the opposite side to `side` (the **aggressor** side):
     /// incoming **buy** consumes **asks** (lowest ask first, FIFO at level); incoming **sell**
     /// consumes **bids** (highest bid first, FIFO at level).
-    fn pop_best(&mut self, side: Side) -> Option<Order>;
-    /// Remove an order from the price book
-    fn remove(&mut self, order_id: &OrderId) -> Option<Order>;
+    fn pop_best(&mut self, side: Side) -> Option<OrderId>;
+    /// Remove `order_id` from the book. Returns whether the id was present in a level queue.
+    fn remove(&mut self, order_id: &OrderId) -> bool;
 }

--- a/src/book/service/btree.rs
+++ b/src/book/service/btree.rs
@@ -3,12 +3,12 @@
 use std::collections::{BTreeMap, HashMap};
 
 use crate::book::PriceBook;
-use crate::types::{Order, OrderId, Price, Side};
+use crate::types::{OrderId, Price, Sequence, Side};
 
-type PriceLevel = BTreeMap<Price, Vec<Order>>;
+type PriceLevel = BTreeMap<Price, Vec<OrderId>>;
 type OrderIndex = HashMap<OrderId, (Price, Side)>;
 
-/// Price book with bids and asks as `BTreeMap<Price, Vec<Order>>`. Best bid = max key,
+/// Price book with bids and asks as `BTreeMap<Price, Vec<OrderId>>`. Best bid = max key,
 /// best ask = min key. FIFO within each level. An index speeds up remove by order id.
 #[derive(Debug, Default)]
 pub struct BTreeOrderBook {
@@ -45,41 +45,51 @@ impl PriceBook for BTreeOrderBook {
         self.asks.keys().next().copied()
     }
 
-    fn push(&mut self, price: &Price, order: &Order) {
-        let side = order.side;
-        self.index.insert(order.id, (*price, side));
+    fn push(
+        &mut self,
+        price: &Price,
+        order_id: OrderId,
+        side: Side,
+        _time_priority: Sequence,
+    ) {
+        self.index.insert(order_id, (*price, side));
         let level = self.side_map_mut(side).entry(*price).or_default();
-        level.push(order.clone());
+        level.push(order_id);
     }
 
-    fn pop_best(&mut self, aggressor_side: Side) -> Option<Order> {
-        let (_best_price, level_key) = match aggressor_side {
+    fn pop_best(&mut self, aggressor_side: Side) -> Option<OrderId> {
+        let level_key = match aggressor_side {
             Side::Buy => self.asks.keys().next().copied(),
             Side::Sell => self.bids.keys().next_back().copied(),
-        }
-        .map(|p| (p, p))?;
+        }?;
         let map = match aggressor_side {
             Side::Buy => &mut self.asks,
             Side::Sell => &mut self.bids,
         };
         let level = map.get_mut(&level_key)?;
-        let order = level.remove(0);
+        let order_id = level.remove(0);
         if level.is_empty() {
             map.remove(&level_key);
         }
-        self.index.remove(&order.id);
-        Some(order)
+        self.index.remove(&order_id);
+        Some(order_id)
     }
 
-    fn remove(&mut self, order_id: &OrderId) -> Option<Order> {
-        let (price, side) = self.index.remove(order_id)?;
+    fn remove(&mut self, order_id: &OrderId) -> bool {
+        let Some((price, side)) = self.index.remove(order_id) else {
+            return false;
+        };
         let map = self.side_map_mut(side);
-        let level = map.get_mut(&price)?;
-        let pos = level.iter().position(|o| o.id == *order_id)?;
-        let order = level.remove(pos);
+        let Some(level) = map.get_mut(&price) else {
+            return false;
+        };
+        let Some(pos) = level.iter().position(|id| id == order_id) else {
+            return false;
+        };
+        level.remove(pos);
         if level.is_empty() {
             map.remove(&price);
         }
-        Some(order)
+        true
     }
 }

--- a/src/book/service/dash_skip.rs
+++ b/src/book/service/dash_skip.rs
@@ -1,5 +1,5 @@
 //! **Phase-1 book:** per-side [`SkipMap`] for ordered **price levels** (best bid / best ask)
-//! and [`DashMap`] for **level queues** (`Price` → `Vec<Order>`), plus a HashMap index for cancel-by-id.
+//! and [`DashMap`] for **level queues** (`Price` → `Vec<OrderId>`), plus a HashMap index for cancel-by-id.
 //!
 //! This layout matches the roadmap: concurrent-friendly maps for later parallel batches, while
 //! [`crate::book::PriceBook`] stays single-writer `&mut self` today.
@@ -12,9 +12,9 @@ use dashmap::DashMap;
 use dashmap::mapref::entry::Entry as DEntry;
 
 use crate::book::PriceBook;
-use crate::types::{Order, OrderId, Price, Side};
+use crate::types::{OrderId, Price, Sequence, Side};
 
-type LevelQueue = Vec<Order>;
+type LevelQueue = Vec<OrderId>;
 type OrderLocation = (Price, Side);
 
 /// Single side: skip list of active prices + dash map of FIFO queues at each price.
@@ -26,56 +26,58 @@ struct BookSide {
 }
 
 impl BookSide {
-    fn push(&mut self, price: Price, order: &Order) {
+    fn push(&mut self, price: Price, order_id: OrderId) {
         match self.levels.entry(price) {
             DEntry::Occupied(mut o) => {
-                o.get_mut().push(order.clone());
+                o.get_mut().push(order_id);
             }
             DEntry::Vacant(v) => {
-                v.insert(vec![order.clone()]);
+                v.insert(vec![order_id]);
                 self.prices.insert(price, ());
             }
         }
     }
 
-    fn pop_best_buy(&mut self) -> Option<Order> {
+    fn pop_best_buy(&mut self) -> Option<OrderId> {
         let price = self.prices.back().map(|e| *e.key())?;
         let mut level = self.levels.get_mut(&price)?;
-        let order = level.remove(0);
+        let order_id = level.remove(0);
         if level.is_empty() {
             drop(level);
             self.levels.remove(&price);
             self.prices.remove(&price);
         }
-        Some(order)
+        Some(order_id)
     }
 
-    fn pop_best_sell(&mut self) -> Option<Order> {
+    fn pop_best_sell(&mut self) -> Option<OrderId> {
         let price = self.prices.front().map(|e| *e.key())?;
         let mut level = self.levels.get_mut(&price)?;
-        let order = level.remove(0);
+        let order_id = level.remove(0);
         if level.is_empty() {
             drop(level);
             self.levels.remove(&price);
             self.prices.remove(&price);
         }
-        Some(order)
+        Some(order_id)
     }
 
-    fn remove_order(
-        &mut self,
-        price: Price,
-        order_id: &OrderId,
-    ) -> Option<Order> {
-        let mut level = self.levels.get_mut(&price)?;
-        let pos = level.iter().position(|o| o.id == *order_id)?;
-        let order = level.remove(pos);
+    fn remove_order(&mut self, price: Price, order_id: &OrderId) -> bool {
+        let mut level = match self.levels.get_mut(&price) {
+            Some(l) => l,
+            None => return false,
+        };
+        let pos = match level.iter().position(|id| id == order_id) {
+            Some(p) => p,
+            None => return false,
+        };
+        level.remove(pos);
         if level.is_empty() {
             drop(level);
             self.levels.remove(&price);
             self.prices.remove(&price);
         }
-        Some(order)
+        true
     }
 
     fn best_buy(&self) -> Option<Price> {
@@ -130,29 +132,36 @@ impl PriceBook for DashSkipOrderBook {
         self.asks.best_sell()
     }
 
-    fn push(&mut self, price: &Price, order: &Order) {
-        self.index.insert(order.id, (*price, order.side));
-        match order.side {
-            Side::Buy => self.bids.push(*price, order),
-            Side::Sell => self.asks.push(*price, order),
+    fn push(
+        &mut self,
+        price: &Price,
+        order_id: OrderId,
+        side: Side,
+        _time_priority: Sequence,
+    ) {
+        self.index.insert(order_id, (*price, side));
+        match side {
+            Side::Buy => self.bids.push(*price, order_id),
+            Side::Sell => self.asks.push(*price, order_id),
         }
     }
 
-    fn pop_best(&mut self, aggressor_side: Side) -> Option<Order> {
-        let order = match aggressor_side {
+    fn pop_best(&mut self, aggressor_side: Side) -> Option<OrderId> {
+        let order_id = match aggressor_side {
             Side::Buy => self.asks.pop_best_sell(),
             Side::Sell => self.bids.pop_best_buy(),
         }?;
-        self.index.remove(&order.id);
-        Some(order)
+        self.index.remove(&order_id);
+        Some(order_id)
     }
 
-    fn remove(&mut self, order_id: &OrderId) -> Option<Order> {
-        let (price, side) = self.index.remove(order_id)?;
-        let order = match side {
+    fn remove(&mut self, order_id: &OrderId) -> bool {
+        let Some((price, side)) = self.index.remove(order_id) else {
+            return false;
+        };
+        match side {
             Side::Buy => self.bids.remove_order(price, order_id),
             Side::Sell => self.asks.remove_order(price, order_id),
-        }?;
-        Some(order)
+        }
     }
 }

--- a/src/book/service/mod.rs
+++ b/src/book/service/mod.rs
@@ -46,27 +46,31 @@ mod tests {
         let mut book = B::default();
         let o1 = order(1, Side::Buy, 100, 10);
         let o2 = order(2, Side::Buy, 101, 5);
-        book.push(&100, &o1);
-        book.push(&101, &o2);
+        book.push(&100, o1.id, o1.side, o1.sequence);
+        book.push(&101, o2.id, o2.side, o2.sequence);
         assert_eq!(book.best_bid(), Some(101));
         assert!(book.best_ask().is_none());
-        book.push(&200, &order(3, Side::Sell, 200, 1));
+        let o3 = order(3, Side::Sell, 200, 1);
+        book.push(&200, o3.id, o3.side, o3.sequence);
         assert_eq!(book.best_ask(), Some(200));
 
         // Aggressor buy pops resting sells (FIFO at best ask).
         let mut book = B::default();
-        book.push(&100, &order(1, Side::Sell, 100, 10));
-        book.push(&100, &order(2, Side::Sell, 100, 5));
-        assert_eq!(book.pop_best(Side::Buy).unwrap().id, 1);
-        assert_eq!(book.pop_best(Side::Buy).unwrap().id, 2);
+        let a = order(1, Side::Sell, 100, 10);
+        let b = order(2, Side::Sell, 100, 5);
+        book.push(&100, a.id, a.side, a.sequence);
+        book.push(&100, b.id, b.side, b.sequence);
+        assert_eq!(book.pop_best(Side::Buy).unwrap(), 1);
+        assert_eq!(book.pop_best(Side::Buy).unwrap(), 2);
         assert!(book.pop_best(Side::Buy).is_none());
 
         let mut book = B::default();
-        book.push(&100, &order(1, Side::Sell, 100, 10));
-        book.push(&100, &order(2, Side::Sell, 100, 5));
-        let r = book.remove(&1).unwrap();
-        assert_eq!(r.id, 1);
-        assert_eq!(book.pop_best(Side::Buy).unwrap().id, 2);
+        let a = order(1, Side::Sell, 100, 10);
+        let b = order(2, Side::Sell, 100, 5);
+        book.push(&100, a.id, a.side, a.sequence);
+        book.push(&100, b.id, b.side, b.sequence);
+        assert!(book.remove(&1));
+        assert_eq!(book.pop_best(Side::Buy).unwrap(), 2);
     }
 
     #[test]

--- a/src/book/service/pool_level.rs
+++ b/src/book/service/pool_level.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 
 use crate::book::PriceBook;
-use crate::types::{Order, OrderId, Price, Side};
+use crate::types::{OrderId, Price, Sequence, Side};
 
 type OrderIndex = HashMap<OrderId, (i64, usize)>;
 
@@ -17,11 +17,11 @@ fn signed_price(price: Price, side: Side) -> i64 {
     }
 }
 
-/// One price level: FIFO list of orders.
+/// One price level: FIFO list of order ids (payload in [`crate::store::OrderStore`]).
 #[derive(Debug, Clone, Default)]
 struct Level {
     signed_price: i64,
-    orders: Vec<Order>,
+    orders: Vec<OrderId>,
 }
 
 /// Pool of levels (alloc/free, no per-level heap beyond the vec).
@@ -100,45 +100,59 @@ impl PriceBook for PoolLevelOrderBook {
         self.levels.range(..0).next_back().map(|(&k, _)| -k)
     }
 
-    fn push(&mut self, price: &Price, order: &Order) {
-        let sp = signed_price(*price, order.side);
+    fn push(
+        &mut self,
+        price: &Price,
+        order_id: OrderId,
+        side: Side,
+        _time_priority: Sequence,
+    ) {
+        let sp = signed_price(*price, side);
         let idx = if let Some(&idx) = self.levels.get(&sp) {
-            self.pool.get_mut(idx).unwrap().orders.push(order.clone());
+            self.pool.get_mut(idx).unwrap().orders.push(order_id);
             idx
         } else {
             let idx = self.pool.alloc(sp);
-            self.pool.get_mut(idx).unwrap().orders.push(order.clone());
+            self.pool.get_mut(idx).unwrap().orders.push(order_id);
             self.levels.insert(sp, idx);
             idx
         };
-        self.index.insert(order.id, (sp, idx));
+        self.index.insert(order_id, (sp, idx));
     }
 
-    fn pop_best(&mut self, aggressor_side: Side) -> Option<Order> {
+    fn pop_best(&mut self, aggressor_side: Side) -> Option<OrderId> {
         let (best_key, level_idx) = match aggressor_side {
             Side::Buy => self.levels.range(..0).next_back(),
             Side::Sell => self.levels.range(0..).next_back(),
         }
         .map(|(k, &v)| (*k, v))?;
         let level = self.pool.get_mut(level_idx)?;
-        let order = level.orders.remove(0);
+        let id = level.orders.remove(0);
         if level.orders.is_empty() {
             self.levels.remove(&best_key);
             self.pool.free(level_idx);
         }
-        self.index.remove(&order.id);
-        Some(order)
+        self.index.remove(&id);
+        Some(id)
     }
 
-    fn remove(&mut self, order_id: &OrderId) -> Option<Order> {
-        let (sp, level_idx) = self.index.remove(order_id)?;
-        let level = self.pool.get_mut(level_idx)?;
-        let pos = level.orders.iter().position(|o| o.id == *order_id)?;
-        let order = level.orders.remove(pos);
+    fn remove(&mut self, order_id: &OrderId) -> bool {
+        let Some((sp, level_idx)) = self.index.remove(order_id) else {
+            return false;
+        };
+        let level = match self.pool.get_mut(level_idx) {
+            Some(l) => l,
+            None => return false,
+        };
+        let pos = match level.orders.iter().position(|id| id == order_id) {
+            Some(p) => p,
+            None => return false,
+        };
+        level.orders.remove(pos);
         if level.orders.is_empty() {
             self.levels.remove(&sp);
             self.pool.free(level_idx);
         }
-        Some(order)
+        true
     }
 }

--- a/src/engine/service.rs
+++ b/src/engine/service.rs
@@ -115,51 +115,58 @@ where
     fn match_and_commit_incoming(&mut self, incoming: &mut Order) -> Result<()> {
         // ─── Matching loop: consume liquidity until none left or order no longer marketable ───
         while incoming.quantity > 0 {
-            // Pop best resting order on the opposite side; stop if book empty.
-            let resting = match self.price_book.pop_best(incoming.side) {
-                Some(o) => o,
+            let resting_id = match self.price_book.pop_best(incoming.side) {
+                Some(id) => id,
                 None => break,
             };
-
-            // Resting limit orders must have a price (book invariant).
+            let mut resting = self.order_store.remove(&resting_id)?;
             let resting_price = match resting.price {
                 Some(p) => p,
                 None => {
+                    self.order_store.insert(&resting)?;
                     return self.emit_rejection(
                         RejectionError::PriceBookInvariantViolation,
                     );
                 }
             };
 
-            // Self-trade policy: reject or adjust if aggressor and resting share participant.
             if self.self_trade_policy.violates(incoming, &resting)? {
+                self.order_store.insert(&resting)?;
+                self.price_book.push(
+                    &resting_price,
+                    resting.id,
+                    resting.side,
+                    resting.sequence,
+                );
                 return self.emit_rejection(RejectionError::SelfTrade);
             }
 
-            // Matching policy: if we cannot match (e.g. price), push resting back and stop.
             if !self.matching_policy.can_match(incoming, &resting)? {
-                self.price_book.push(&resting_price, &resting);
+                self.order_store.insert(&resting)?;
+                self.price_book.push(
+                    &resting_price,
+                    resting.id,
+                    resting.side,
+                    resting.sequence,
+                );
                 break;
             }
 
-            // Execute fill: reduce quantities, update or remove resting, emit Trade.
             let traded_qty = incoming.quantity.min(resting.leaves_quantity);
             incoming.quantity -= traded_qty;
             incoming.leaves_quantity = incoming.quantity;
-
             let remaining_qty = resting.leaves_quantity - traded_qty;
 
-            self.order_store.remove(&resting.id)?;
             if remaining_qty > 0 {
-                let updated = Order {
-                    quantity: resting.quantity,
-                    leaves_quantity: remaining_qty,
-                    executed_quantity: resting.executed_quantity + traded_qty,
-                    ..resting.clone()
-                };
-
-                self.order_store.insert(&updated)?;
-                self.price_book.push(&resting_price, &updated);
+                resting.executed_quantity += traded_qty;
+                resting.leaves_quantity = remaining_qty;
+                self.order_store.insert(&resting)?;
+                self.price_book.push(
+                    &resting_price,
+                    resting.id,
+                    resting.side,
+                    resting.sequence,
+                );
             }
 
             self.event_sink.emit(Event::Trade(Trade {
@@ -181,7 +188,12 @@ where
                 TimeInForce::Gtc => {
                     self.order_store.insert(incoming)?;
                     if let Some(price) = incoming.price {
-                        self.price_book.push(&price, incoming);
+                        self.price_book.push(
+                            &price,
+                            incoming.id,
+                            incoming.side,
+                            incoming.sequence,
+                        );
                     }
                     self.event_sink.emit(Event::Accepted(incoming.id))?;
                 }
@@ -268,7 +280,7 @@ where
         // ─── CANCEL: Remove from store and book ───
         // 2. Remove from store (authoritative); then from book (derived).
         let order = self.order_store.remove(&cmd.order_id)?;
-        if self.price_book.remove(&order.id).is_none() {
+        if !self.price_book.remove(&order.id) {
             return self
                 .emit_rejection(RejectionError::PriceBookInvariantViolation);
         }
@@ -300,7 +312,7 @@ where
         // ─── REPLACE: Cancel old order (store and book) ───
         // 3. Remove old from store then book; emit Canceled (replace = cancel + add semantics).
         let old = self.order_store.remove(&cmd.order_id)?;
-        if self.price_book.remove(&old.id).is_none() {
+        if !self.price_book.remove(&old.id) {
             return self
                 .emit_rejection(RejectionError::PriceBookInvariantViolation);
         }
@@ -341,7 +353,7 @@ where
             }
             Err(e) => return Err(e.into()),
         };
-        if self.price_book.remove(&order.id).is_none() {
+        if !self.price_book.remove(&order.id) {
             return self
                 .emit_rejection(RejectionError::PriceBookInvariantViolation);
         }
@@ -378,7 +390,8 @@ where
         self.order_store.remove(&order.id)?;
         self.price_book.remove(&order.id);
         self.order_store.insert(&order)?;
-        self.price_book.push(&price, &order);
+        self.price_book
+            .push(&price, order.id, order.side, order.sequence);
         Ok(())
     }
 
@@ -409,7 +422,8 @@ where
             self.order_store.remove(&order.id)?;
             self.price_book.remove(&order.id);
             self.order_store.insert(&order)?;
-            self.price_book.push(&price, &order);
+            self.price_book
+                .push(&price, order.id, order.side, order.sequence);
         }
         Ok(())
     }
@@ -430,7 +444,7 @@ where
             }
             Err(e) => return Err(e.into()),
         };
-        if self.price_book.remove(&old.id).is_none() {
+        if !self.price_book.remove(&old.id) {
             return self
                 .emit_rejection(RejectionError::PriceBookInvariantViolation);
         }
@@ -634,10 +648,12 @@ mod tests {
             executed_quantity: 0,
             ..Order::default()
         };
-        book.expect_pop_best()
-            .return_once(move |_| Some(order_no_price));
-        book.expect_push().returning(|_, _| {});
-        let store = MockOrderStore::new();
+        book.expect_pop_best().return_once(|_| Some(1));
+        let mut store = MockOrderStore::new();
+        store
+            .expect_remove()
+            .return_once(move |_| Ok(order_no_price));
+        store.expect_insert().return_once(|_| Ok(()));
         let matching = MockMatchingPolicy::new();
         let mut self_trade = MockSelfTradePolicy::new();
         self_trade.expect_violates().returning(|_, _| Ok(false));
@@ -687,9 +703,9 @@ mod tests {
             executed_quantity: 0,
             ..Order::default()
         };
-        book.expect_pop_best().return_once(move |_| Some(resting));
-        book.expect_push().returning(|_, _| {});
-        let store = MockOrderStore::new();
+        book.expect_pop_best().return_once(|_| Some(1));
+        let mut store = MockOrderStore::new();
+        store.expect_remove().return_once(move |_| Ok(resting));
         let matching = MockMatchingPolicy::new();
         let mut self_trade = MockSelfTradePolicy::new();
         self_trade.expect_violates().return_once(|_, _| {
@@ -737,9 +753,9 @@ mod tests {
             executed_quantity: 0,
             ..Order::default()
         };
-        book.expect_pop_best().return_once(move |_| Some(resting));
-        book.expect_push().returning(|_, _| {});
-        let store = MockOrderStore::new();
+        book.expect_pop_best().return_once(|_| Some(1));
+        let mut store = MockOrderStore::new();
+        store.expect_remove().return_once(move |_| Ok(resting));
         let mut matching = MockMatchingPolicy::new();
         matching
             .expect_can_match()
@@ -775,20 +791,7 @@ mod tests {
         let mut seq = MockSequenceGenerator::new();
         seq.expect_next().returning(|| Ok(0));
         let mut book = MockPriceBook::new();
-        let resting = Order {
-            id: 1,
-            participant_id: 100,
-            side: Side::Sell,
-            order_type: OrderType::Limit,
-            price: Some(50),
-            quantity: 10,
-            time_in_force: TimeInForce::Gtc,
-            sequence: 0,
-            leaves_quantity: 10,
-            executed_quantity: 0,
-            ..Order::default()
-        };
-        book.expect_pop_best().return_once(move |_| Some(resting));
+        book.expect_pop_best().return_once(|_| Some(1));
         let mut store = MockOrderStore::new();
         store
             .expect_remove()
@@ -845,7 +848,7 @@ mod tests {
             let mut c = pop_count.borrow_mut();
             *c += 1;
             if *c == 1 {
-                Some(resting_clone.clone())
+                Some(resting_clone.id)
             } else {
                 None
             }
@@ -903,7 +906,7 @@ mod tests {
         seq.expect_next().return_once(|| Ok(0));
         let mut book = MockPriceBook::new();
         book.expect_pop_best().returning(|_| None);
-        book.expect_push().returning(|_, _| {});
+        book.expect_push().returning(|_, _, _, _| {});
         let mut store = MockOrderStore::new();
         store.expect_insert().returning(|_| Ok(()));
         let matching = MockMatchingPolicy::new();
@@ -978,21 +981,7 @@ mod tests {
     fn cancel_emit_canceled_err() {
         let seq = MockSequenceGenerator::new();
         let mut book = MockPriceBook::new();
-        book.expect_remove().return_once(|_| {
-            Some(Order {
-                id: 1,
-                participant_id: 100,
-                side: Side::Buy,
-                order_type: OrderType::Limit,
-                price: Some(50),
-                quantity: 10,
-                time_in_force: TimeInForce::Gtc,
-                sequence: 0,
-                leaves_quantity: 10,
-                executed_quantity: 0,
-                ..Order::default()
-            })
-        });
+        book.expect_remove().return_once(|_| true);
         let mut store = MockOrderStore::new();
         store.expect_get().return_once(|&id| {
             Some(Order {
@@ -1048,7 +1037,7 @@ mod tests {
     fn cancel_book_remove_none_invariant_violation() {
         let seq = MockSequenceGenerator::new();
         let mut book = MockPriceBook::new();
-        book.expect_remove().return_once(|_| None);
+        book.expect_remove().return_once(|_| false);
         let mut store = MockOrderStore::new();
         store.expect_get().return_once(|&id| {
             Some(Order {
@@ -1144,21 +1133,7 @@ mod tests {
     fn replace_emit_canceled_err() {
         let seq = MockSequenceGenerator::new();
         let mut book = MockPriceBook::new();
-        book.expect_remove().return_once(|_| {
-            Some(Order {
-                id: 1,
-                participant_id: 100,
-                side: Side::Buy,
-                order_type: OrderType::Limit,
-                price: Some(50),
-                quantity: 10,
-                time_in_force: TimeInForce::Gtc,
-                sequence: 0,
-                leaves_quantity: 10,
-                executed_quantity: 0,
-                ..Order::default()
-            })
-        });
+        book.expect_remove().return_once(|_| true);
         let mut store = MockOrderStore::new();
         store.expect_get().return_once(|&id| {
             Some(Order {
@@ -1215,7 +1190,7 @@ mod tests {
     fn replace_book_remove_none_invariant_violation() {
         let seq = MockSequenceGenerator::new();
         let mut book = MockPriceBook::new();
-        book.expect_remove().return_once(|_| None);
+        book.expect_remove().return_once(|_| false);
         let mut store = MockOrderStore::new();
         store.expect_get().return_once(|&id| {
             Some(Order {
@@ -1272,21 +1247,7 @@ mod tests {
     fn replace_sequence_err() {
         let mut seq = MockSequenceGenerator::new();
         let mut book = MockPriceBook::new();
-        book.expect_remove().return_once(|_| {
-            Some(Order {
-                id: 1,
-                participant_id: 100,
-                side: Side::Buy,
-                order_type: OrderType::Limit,
-                price: Some(50),
-                quantity: 10,
-                time_in_force: TimeInForce::Gtc,
-                sequence: 0,
-                leaves_quantity: 10,
-                executed_quantity: 0,
-                ..Order::default()
-            })
-        });
+        book.expect_remove().return_once(|_| true);
         let mut store = MockOrderStore::new();
         store.expect_get().return_once(|&id| {
             Some(Order {
@@ -1345,21 +1306,7 @@ mod tests {
         seq.expect_next_at_end_of_queue().return_once(|| Ok(1));
         let mut book = MockPriceBook::new();
         book.expect_pop_best().returning(|_| None);
-        book.expect_remove().return_once(|_| {
-            Some(Order {
-                id: 1,
-                participant_id: 100,
-                side: Side::Buy,
-                order_type: OrderType::Limit,
-                price: Some(50),
-                quantity: 10,
-                time_in_force: TimeInForce::Gtc,
-                sequence: 0,
-                leaves_quantity: 10,
-                executed_quantity: 0,
-                ..Order::default()
-            })
-        });
+        book.expect_remove().return_once(|_| true);
         let mut store = MockOrderStore::new();
         store.expect_get().return_once(|&id| {
             Some(Order {
@@ -1419,21 +1366,7 @@ mod tests {
         seq.expect_next_at_end_of_queue().return_once(|| Ok(1));
         let mut book = MockPriceBook::new();
         book.expect_pop_best().returning(|_| None);
-        book.expect_remove().return_once(|_| {
-            Some(Order {
-                id: 1,
-                participant_id: 100,
-                side: Side::Sell,
-                order_type: OrderType::Market,
-                price: None,
-                quantity: 10,
-                time_in_force: TimeInForce::Gtc,
-                sequence: 0,
-                leaves_quantity: 10,
-                executed_quantity: 0,
-                ..Order::default()
-            })
-        });
+        book.expect_remove().return_once(|_| true);
         let mut store = MockOrderStore::new();
         store.expect_get().return_once(|&id| {
             Some(Order {
@@ -1489,22 +1422,8 @@ mod tests {
         seq.expect_next_at_end_of_queue().return_once(|| Ok(1));
         let mut book = MockPriceBook::new();
         book.expect_pop_best().returning(|_| None);
-        book.expect_remove().return_once(|_| {
-            Some(Order {
-                id: 1,
-                participant_id: 100,
-                side: Side::Buy,
-                order_type: OrderType::Limit,
-                price: Some(50),
-                quantity: 10,
-                time_in_force: TimeInForce::Gtc,
-                sequence: 0,
-                leaves_quantity: 10,
-                executed_quantity: 0,
-                ..Order::default()
-            })
-        });
-        book.expect_push().returning(|_, _| {});
+        book.expect_remove().return_once(|_| true);
+        book.expect_push().returning(|_, _, _, _| {});
         let mut store = MockOrderStore::new();
         store.expect_get().return_once(|&id| {
             Some(Order {

--- a/src/harness/memory.rs
+++ b/src/harness/memory.rs
@@ -4,12 +4,12 @@
 
 use crate::book::PriceBook;
 use crate::store::{OrderStore, OrderStoreError};
-use crate::types::{Order, OrderId, Price, Quantity, Side};
+use crate::types::{Order, OrderId, Price, Quantity, Sequence, Side};
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::rc::Rc;
 
-type PriceLevel = BTreeMap<Price, VecDeque<Order>>;
+type PriceLevel = BTreeMap<Price, VecDeque<(OrderId, Sequence)>>;
 
 #[derive(Default)]
 pub struct InMemoryPriceBook {
@@ -21,13 +21,20 @@ impl InMemoryPriceBook {
     fn push_side(
         side: Side,
         price: Price,
-        order: &Order,
+        order_id: OrderId,
+        time_priority: Sequence,
         bids: &mut PriceLevel,
         asks: &mut PriceLevel,
     ) {
         match side {
-            Side::Buy => bids.entry(price).or_default().push_back(order.clone()),
-            Side::Sell => asks.entry(price).or_default().push_back(order.clone()),
+            Side::Buy => bids
+                .entry(price)
+                .or_default()
+                .push_back((order_id, time_priority)),
+            Side::Sell => asks
+                .entry(price)
+                .or_default()
+                .push_back((order_id, time_priority)),
         }
     }
 
@@ -35,7 +42,7 @@ impl InMemoryPriceBook {
         side: Side,
         bids: &mut PriceLevel,
         asks: &mut PriceLevel,
-    ) -> Option<Order> {
+    ) -> Option<OrderId> {
         let (best_price, q) = match side {
             Side::Buy => {
                 let best_ask = asks.keys().next().copied()?;
@@ -51,9 +58,9 @@ impl InMemoryPriceBook {
         let idx = q
             .iter()
             .enumerate()
-            .min_by_key(|(_, o)| o.sequence)
+            .min_by_key(|(_, (_, seq))| *seq)
             .map(|(i, _)| i)?;
-        let order = q.remove(idx)?;
+        let (order_id, _) = q.remove(idx)?;
         if q.is_empty() {
             match side {
                 Side::Buy => {
@@ -64,25 +71,27 @@ impl InMemoryPriceBook {
                 }
             }
         }
-        Some(order)
+        Some(order_id)
     }
 
     fn remove_from_side(
         order_id: &OrderId,
         bids: &mut PriceLevel,
         asks: &mut PriceLevel,
-    ) -> Option<Order> {
+    ) -> bool {
         for q in bids.values_mut() {
-            if let Some(pos) = q.iter().position(|o| o.id == *order_id) {
-                return Some(q.remove(pos).unwrap());
+            if let Some(pos) = q.iter().position(|(id, _)| id == order_id) {
+                q.remove(pos).unwrap();
+                return true;
             }
         }
         for q in asks.values_mut() {
-            if let Some(pos) = q.iter().position(|o| o.id == *order_id) {
-                return Some(q.remove(pos).unwrap());
+            if let Some(pos) = q.iter().position(|(id, _)| id == order_id) {
+                q.remove(pos).unwrap();
+                return true;
             }
         }
-        None
+        false
     }
 }
 
@@ -95,21 +104,28 @@ impl PriceBook for InMemoryPriceBook {
         self.asks.keys().next().copied()
     }
 
-    fn push(&mut self, price: &Price, order: &Order) {
+    fn push(
+        &mut self,
+        price: &Price,
+        order_id: OrderId,
+        side: Side,
+        time_priority: Sequence,
+    ) {
         Self::push_side(
-            order.side,
+            side,
             *price,
-            order,
+            order_id,
+            time_priority,
             &mut self.bids,
             &mut self.asks,
         );
     }
 
-    fn pop_best(&mut self, side: Side) -> Option<Order> {
+    fn pop_best(&mut self, side: Side) -> Option<OrderId> {
         Self::pop_best_side(side, &mut self.bids, &mut self.asks)
     }
 
-    fn remove(&mut self, order_id: &OrderId) -> Option<Order> {
+    fn remove(&mut self, order_id: &OrderId) -> bool {
         Self::remove_from_side(order_id, &mut self.bids, &mut self.asks)
     }
 }
@@ -141,18 +157,22 @@ impl OrderStore for InMemoryOrderStore {
 
 impl InMemoryPriceBook {
     #[allow(dead_code)]
-    pub fn total_depth(&self) -> Quantity {
+    /// Sum of `leaves_quantity` for ids queued in the book, resolved via `resolve` (usually [`OrderStore::get`]).
+    pub fn total_depth<F>(&self, mut resolve: F) -> Quantity
+    where
+        F: FnMut(OrderId) -> Option<Quantity>,
+    {
         let bid_qty: Quantity = self
             .bids
             .values()
             .flat_map(|q| q.iter())
-            .map(|o| o.quantity)
+            .filter_map(|&(id, _)| resolve(id))
             .sum();
         let ask_qty: Quantity = self
             .asks
             .values()
             .flat_map(|q| q.iter())
-            .map(|o| o.quantity)
+            .filter_map(|&(id, _)| resolve(id))
             .sum();
         bid_qty + ask_qty
     }
@@ -171,13 +191,25 @@ impl PriceBook for SharedPriceBookHandle {
     fn best_ask(&self) -> Option<Price> {
         PriceBook::best_ask(&*self.0.borrow())
     }
-    fn push(&mut self, price: &Price, order: &Order) {
-        PriceBook::push(&mut *self.0.borrow_mut(), price, order)
+    fn push(
+        &mut self,
+        price: &Price,
+        order_id: OrderId,
+        side: Side,
+        time_priority: Sequence,
+    ) {
+        PriceBook::push(
+            &mut *self.0.borrow_mut(),
+            price,
+            order_id,
+            side,
+            time_priority,
+        )
     }
-    fn pop_best(&mut self, side: Side) -> Option<Order> {
+    fn pop_best(&mut self, side: Side) -> Option<OrderId> {
         PriceBook::pop_best(&mut *self.0.borrow_mut(), side)
     }
-    fn remove(&mut self, order_id: &OrderId) -> Option<Order> {
+    fn remove(&mut self, order_id: &OrderId) -> bool {
         PriceBook::remove(&mut *self.0.borrow_mut(), order_id)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@
 //! 1. [`types`] — `Order`, `Price`, `Quantity`, sides, time-in-force.
 //! 2. [`engine`] — commands such as [`OrderCommand`](engine::OrderCommand) (see `engine/models.rs` in source).
 //! 3. [`engine::OrderMatchingEngine`] — wires policies, book, and store; batch feeds via **[`OrderMatchingEngine::process_batch`](engine::OrderMatchingEngine::process_batch)**.
+//! 4. [`pool`] — optional `Order` shell recycling for adapters.
+//! 5. **[`parallel`]** (feature **`parallel`**) — read-mostly `rayon` helpers; the book stays single-writer.
 //!
 //! # Tests and in-memory setup
 //!
@@ -32,10 +34,14 @@ pub mod error;
 pub mod events;
 pub mod itch;
 pub mod matching;
+pub mod pool;
 pub mod self_trade;
 pub mod sequence;
 pub mod store;
 pub mod types;
+
+#[cfg(feature = "parallel")]
+pub mod parallel;
 
 #[cfg(feature = "harness")]
 pub mod harness;

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -1,0 +1,44 @@
+//! Read-mostly parallel helpers (optional **`rayon`** feature).
+//!
+//! The matching engine and each [`crate::book::PriceBook`] remain **single-writer**; this module
+//! is for **aggregating** best bid/ask (or similar) across many books/locks in parallel.
+
+use crate::book::PriceBook;
+use crate::types::Price;
+
+use rayon::prelude::*;
+
+/// One book’s best bid and ask.
+pub type BestBidAsk = (Option<Price>, Option<Price>);
+
+/// Best bid/ask per book, computed in parallel (each `PB` must be safe to share across threads).
+pub fn par_best_quotes<PB>(books: &[PB]) -> Vec<BestBidAsk>
+where
+    PB: PriceBook + Sync,
+{
+    books
+        .par_iter()
+        .map(|b| (b.best_bid(), b.best_ask()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::book::PriceBook;
+    use crate::book::service::BTreeOrderBook;
+    use crate::types::Side;
+
+    #[test]
+    fn par_best_quotes_matches_sequential() {
+        let mut a = BTreeOrderBook::new();
+        let mut b = BTreeOrderBook::new();
+        a.push(&10, 1, Side::Buy, 0);
+        b.push(&20, 2, Side::Sell, 0);
+        let books = [a, b];
+        let seq: Vec<_> =
+            books.iter().map(|x| (x.best_bid(), x.best_ask())).collect();
+        let par = par_best_quotes(&books);
+        assert_eq!(par, seq);
+    }
+}

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -1,0 +1,52 @@
+//! Object pool for [`crate::types::Order`] shells (optional integration in hot clients).
+//!
+//! Resting order **payloads** live in [`crate::store::OrderStore`]; this pool only recycles
+//! allocated `Order` structs when you build commands or temporary copies outside the engine.
+
+use crate::types::Order;
+
+/// Reuses `Order` allocations between logical lifetimes (fill/cancel/custom adapters).
+#[derive(Debug, Default)]
+pub struct OrderPool {
+    free: Vec<Order>,
+}
+
+impl OrderPool {
+    /// Returns a cleared shell from the pool or [`Order::default`].
+    pub fn take(&mut self) -> Order {
+        self.free.pop().unwrap_or_default()
+    }
+
+    /// Returns a used shell to the pool (replaced with a default instance for reuse).
+    pub fn recycle(&mut self, _finished: Order) {
+        self.free.push(Order::default());
+    }
+
+    /// Clears pooled entries (e.g. after a bounded test batch).
+    pub fn clear(&mut self) {
+        self.free.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{OrderType, Side, TimeInForce};
+
+    #[test]
+    fn take_recycle_roundtrip() {
+        let mut p = OrderPool::default();
+        let mut o = p.take();
+        o.id = 42;
+        o.side = Side::Sell;
+        o.order_type = OrderType::Limit;
+        o.price = Some(100);
+        o.quantity = 1;
+        o.leaves_quantity = 1;
+        o.time_in_force = TimeInForce::Gtc;
+        p.recycle(o);
+        let o2 = p.take();
+        assert_eq!(o2.id, 0);
+        assert_eq!(o2.side, Side::Buy);
+    }
+}

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -15,7 +15,7 @@ pub trait OrderStore {
     fn insert(&mut self, order: &Order) -> Result<(), OrderStoreError>;
     /// Remove an order from the store
     fn remove(&mut self, order_id: &OrderId) -> Result<Order, OrderStoreError>;
-    /// Get an order from the store
+    /// Get a clone of the resting order (canonical copy in the store).
     fn get(&self, order_id: &OrderId) -> Option<Order>;
 }
 

--- a/tests/book_integrity.rs
+++ b/tests/book_integrity.rs
@@ -51,7 +51,7 @@ fn no_crossed_book() {
 /// VIII.2 Depth correctness: total depth equals sum of resting quantities.
 #[test]
 fn depth_correctness() {
-    let (mut engine, _sink, book_handle, _store_handle) =
+    let (mut engine, _sink, book_handle, store_handle) =
         engine_with_shared_state();
     let a = add_cmd(
         1,
@@ -84,7 +84,8 @@ fn depth_correctness() {
     engine.add(b).unwrap();
     engine.add(c).unwrap();
     let book = book_handle.borrow();
-    let total = book.total_depth();
+    let store = store_handle.borrow();
+    let total = book.total_depth(|id| store.get(&id).map(|o| o.leaves_quantity));
     assert_eq!(
         total,
         5 + 10 + 7,

--- a/tests/determinism_replay.rs
+++ b/tests/determinism_replay.rs
@@ -8,6 +8,7 @@ use common::{
     EventSnapshot, add_cmd, engine_with_memory, engine_with_shared_state,
 };
 use omer::engine::{OrderCommand, OrderMatchingService};
+use omer::store::OrderStore;
 use omer::types::{OrderType, Side, TimeInForce};
 
 /// IX.1 Deterministic execution: same sequence yields same events and outcome.
@@ -74,8 +75,8 @@ fn deterministic_execution() {
 /// when both complete, then the event logs and final book state (depth) must be identical.
 #[test]
 fn snapshot_replay_state_matches() {
-    let (mut engine1, sink1, book1, _store1) = engine_with_shared_state();
-    let (mut engine2, sink2, book2, _store2) = engine_with_shared_state();
+    let (mut engine1, sink1, book1, store1) = engine_with_shared_state();
+    let (mut engine2, sink2, book2, store2) = engine_with_shared_state();
 
     let cmds: Vec<OrderCommand> = vec![
         OrderCommand::Add(add_cmd(
@@ -139,7 +140,11 @@ fn snapshot_replay_state_matches() {
         }
     }
 
-    let depth1 = book1.borrow().total_depth();
-    let depth2 = book2.borrow().total_depth();
+    let depth1 = book1
+        .borrow()
+        .total_depth(|id| store1.borrow().get(&id).map(|o| o.leaves_quantity));
+    let depth2 = book2
+        .borrow()
+        .total_depth(|id| store2.borrow().get(&id).map(|o| o.leaves_quantity));
     assert_eq!(depth1, depth2, "final book depth must match after replay");
 }

--- a/tests/proptest_store_roundtrip.rs
+++ b/tests/proptest_store_roundtrip.rs
@@ -1,0 +1,44 @@
+//! Property: basic store insert/remove roundtrip holds for dense ids.
+
+use omer::store::service::HashMapOrderStore;
+use omer::store::{OrderStore, OrderStoreError};
+use omer::types::{Order, OrderType, Side, TimeInForce};
+use proptest::prelude::*;
+
+fn order_with_id(id: u64) -> Order {
+    Order {
+        symbol_id: 0,
+        id,
+        participant_id: 1,
+        side: Side::Buy,
+        order_type: OrderType::Limit,
+        price: Some(100),
+        quantity: 10,
+        time_in_force: TimeInForce::Gtc,
+        leaves_quantity: 10,
+        executed_quantity: 0,
+        sequence: 0,
+        ..Order::default()
+    }
+}
+
+proptest! {
+    #[test]
+    fn hash_map_store_insert_remove_roundtrip(id in 1u64..10_000u64) {
+        let mut s = HashMapOrderStore::new();
+        let o = order_with_id(id);
+        s.insert(&o).unwrap();
+        assert_eq!(s.get(&id).unwrap().id, id);
+        assert_eq!(s.remove(&id).unwrap().id, id);
+        assert!(s.get(&id).is_none());
+    }
+
+    #[test]
+    fn hash_map_store_double_insert_err(id in 1u64..10_000u64) {
+        let mut s = HashMapOrderStore::new();
+        let o = order_with_id(id);
+        s.insert(&o).unwrap();
+        let e = s.insert(&o).unwrap_err();
+        prop_assert!(matches!(e, OrderStoreError::AlreadyExists(x) if x == id));
+    }
+}


### PR DESCRIPTION
BREAKING CHANGE: PriceBook::push now takes (price, order_id, side, time_priority); pop_best returns OrderId; remove returns bool. Resting payloads live only in OrderStore; matching removes from store after pop for trading. GTC and self-trade no-match paths restore store+book consistently. Match-remove failures surface OrderStoreError. InMemoryPriceBook orders levels by sequence.

- Add OrderPool for recycling Order shells outside the engine
- Feature parallel + par_best_quotes (rayon) for read-mostly aggregation
- proptest store roundtrip tests; CONTRIBUTING process; README layout/install/usage
- Makefile quality-gate (pmat check subset); throughput_book bench uses ids only