### PR TITLE
bench: sharded multi-book throughput targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,3 +117,13 @@ required-features = ["harness"]
 name = "parallel_best_quotes"
 harness = false
 required-features = ["parallel"]
+
+[[bench]]
+name = "throughput_sharded_add"
+harness = false
+required-features = ["harness", "parallel"]
+
+[[bench]]
+name = "throughput_sharded_book_push"
+harness = false
+required-features = ["parallel"]

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ Disable harness: `omer = { version = "…", default-features = false }`.
 | `integrity_stress` | `cargo bench -p omer --bench integrity_stress` | Deterministic mixed ops + `assert_uncrossed` (Criterion needs `--sample-size` ≥ 10) |
 | `observability_overhead` | `cargo bench -p omer --features harness --bench observability_overhead` | Same add pattern: `NoOpEventSink` vs collecting harness sink |
 | `parallel_best_quotes` | `cargo bench -p omer --features parallel --bench parallel_best_quotes` | 256 `BTreeOrderBook` instances: sequential best-quote scan vs `par_best_quotes` |
+| `throughput_sharded_add` | `cargo bench -p omer --features harness,parallel --bench throughput_sharded_add` | Sharded add-only workload: one engine per shard, adds executed in parallel (`rayon`) |
+| `throughput_sharded_book_push` | `cargo bench -p omer --features parallel --bench throughput_sharded_book_push` | Sharded book-only `DashSkipOrderBook::push` in parallel; same-price FIFO vs distinct prices |
 | `itch_parse` | `cargo bench -p omer --bench itch_parse` | `scan_decode_book_messages` on 50k AddOrder packets in one buffer |
 | `micro` | `cargo bench -p omer --bench micro` | Near-no-op Criterion smoke (picosecond-scale; not engine work) |
 | `matching_engine`, `market_manager` | same pattern | ITCH-shaped smoke benches |
@@ -118,7 +120,7 @@ CI compiles benches with `cargo bench --no-run --workspace --all-features` but d
 
 ### Observed results (reference machine)
 
-One **release** run on **Linux 6.5**, **rustc 1.94.1**, with Criterion short sampling (`--sample-size 10`, ~0.15–0.25 s measurement). Values are **medians** (middle of Criterion’s printed `[lower, estimate, upper]` interval)—use for regression trending, not as absolute guarantees.
+One **release** run on **Linux 6.5**, **rustc 1.94.1**, **Intel i7-13650HX (20 CPUs)**, with Criterion short sampling (`--sample-size 10`, ~0.15–0.25 s measurement). Values are **medians** (middle of Criterion’s printed `[lower, estimate, upper]` interval)—use for regression trending, not as absolute guarantees.
 
 | Bench / function | Median | Notes |
 |------------------|--------|--------|
@@ -140,6 +142,8 @@ One **release** run on **Linux 6.5**, **rustc 1.94.1**, with Criterion short sam
 | `integrity_stress` / randomish stream | **~3.75 ms** | Per iteration; includes invariant check |
 | `observability_overhead` / noop vs collecting add | **~189 ns vs ~141 ns** | Overlapping CIs—treat delta as noisy at this sampling depth |
 | `parallel_best_quotes` / sequential vs `rayon` | **~710 ns vs ~19.9 µs** | 256 tiny books: parallel fork/join dominates; scale up book count or work per book to see win |
+| `throughput_sharded_add` / 20 shards add-only | **~19.1 Melem/s** | Aggregate across shards; still far from 1B ops/s without further batching/layout work |
+| `throughput_sharded_book_push` / 20 shards same-price FIFO | **~57.8 Melem/s** | Upper bound (book-only). Distinct prices median was **~23.8 Melem/s** |
 
 `micro` / `matching_engine` / `market_manager` report **~210 ps** per iter (empty loops)—kept as compile/smoke anchors only.
 

--- a/benches/throughput_sharded_add.rs
+++ b/benches/throughput_sharded_add.rs
@@ -1,0 +1,76 @@
+//! Sharded **multi-book** throughput: parallel add-only workload across independent engines.
+//!
+//! This is the closest “north star” proxy in-tree today: single-writer per book, scale via shards.
+
+use std::hint::black_box;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use omer::engine::{AddOrderCommand, OrderMatchingService};
+use omer::harness::{
+    EngineWithBookNoOp, InMemoryPriceBook, engine_with_book_noop,
+};
+use omer::types::{OrderType, Side, TimeInForce};
+use rayon::prelude::*;
+
+const OPS_PER_SHARD: u64 = 100_000;
+
+type ShardEngine = EngineWithBookNoOp<InMemoryPriceBook>;
+
+fn mk_resting_add(id: u64, symbol_id: u32) -> AddOrderCommand {
+    AddOrderCommand {
+        id,
+        participant_id: 100,
+        symbol_id,
+        side: Side::Buy,
+        order_type: OrderType::Limit,
+        price: Some(100 + (id as i64 % 400)),
+        quantity: 1,
+        time_in_force: TimeInForce::Gtc,
+        stop_price: None,
+        max_visible_quantity: None,
+        slippage: None,
+        trailing_distance: None,
+        trailing_step: None,
+    }
+}
+
+fn throughput_sharded_add(c: &mut Criterion) {
+    let shards = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+
+    let mut engines: Vec<ShardEngine> =
+        (0..shards).map(|_| engine_with_book_noop()).collect();
+    let next_ids: Vec<AtomicU64> = (0..shards)
+        .map(|i| AtomicU64::new(1 + (i as u64).wrapping_mul(1_000_000_000)))
+        .collect();
+
+    let mut group = c.benchmark_group("throughput_sharded_add");
+    group.throughput(Throughput::Elements(OPS_PER_SHARD * shards as u64));
+
+    group.bench_function("inmemory_price_book_noop_sink", |b| {
+        b.iter(|| {
+            engines
+                .par_iter_mut()
+                .enumerate()
+                .for_each(|(shard_idx, engine)| {
+                    let mut id = next_ids[shard_idx].load(Ordering::Relaxed);
+                    let symbol_id = shard_idx as u32 + 1;
+                    for _ in 0..OPS_PER_SHARD {
+                        // NB: symbol id is stable per shard; ids are monotonic per shard.
+                        black_box(
+                            engine.add(mk_resting_add(id, symbol_id)).is_ok(),
+                        );
+                        id = id.wrapping_add(1);
+                    }
+                    next_ids[shard_idx].store(id, Ordering::Relaxed);
+                });
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, throughput_sharded_add);
+criterion_main!(benches);

--- a/benches/throughput_sharded_book_push.rs
+++ b/benches/throughput_sharded_book_push.rs
@@ -1,0 +1,76 @@
+//! Sharded book-only throughput: parallel [`PriceBook::push`] across independent books.
+//!
+//! This is an **upper bound** for shard scaling since it excludes store/policies/events.
+
+use std::hint::black_box;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use omer::book::PriceBook;
+use omer::book::service::DashSkipOrderBook;
+use omer::types::Side;
+use rayon::prelude::*;
+
+const OPS_PER_SHARD: u64 = 200_000;
+
+type Book = DashSkipOrderBook;
+
+fn throughput_sharded_book_push(c: &mut Criterion) {
+    let shards = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+
+    // Reuse books across iterations so we measure push hot path, not allocator setup.
+    let mut books: Vec<Book> = (0..shards).map(|_| Book::new()).collect();
+    let next_order_id: Vec<AtomicU64> =
+        (0..shards).map(|i| AtomicU64::new(i as u64)).collect();
+    let next_price: Vec<AtomicU64> = (0..shards)
+        .map(|i| AtomicU64::new(10_000 + (i as u64) * 1_000_000))
+        .collect();
+
+    let mut group = c.benchmark_group("throughput_sharded_book_push");
+    group.throughput(Throughput::Elements(OPS_PER_SHARD * shards as u64));
+
+    group.bench_function("dash_skip_push_same_price_fifo", |b| {
+        b.iter(|| {
+            books
+                .par_iter_mut()
+                .enumerate()
+                .for_each(|(shard_idx, book)| {
+                    let mut id = next_order_id[shard_idx].load(Ordering::Relaxed);
+                    for _ in 0..OPS_PER_SHARD {
+                        book.push(&100, id, Side::Buy, id);
+                        id = id.wrapping_add(1);
+                    }
+                    next_order_id[shard_idx].store(id, Ordering::Relaxed);
+                    black_box(book.best_bid());
+                });
+        });
+    });
+
+    group.bench_function("dash_skip_push_distinct_prices", |b| {
+        b.iter(|| {
+            books
+                .par_iter_mut()
+                .enumerate()
+                .for_each(|(shard_idx, book)| {
+                    let mut id = next_order_id[shard_idx].load(Ordering::Relaxed);
+                    let mut p = next_price[shard_idx].load(Ordering::Relaxed);
+                    for _ in 0..OPS_PER_SHARD {
+                        // Monotonic prices within a shard to avoid intra-level FIFO effects.
+                        book.push(&(p as i64), id, Side::Buy, id);
+                        id = id.wrapping_add(1);
+                        p = p.wrapping_add(1);
+                    }
+                    next_order_id[shard_idx].store(id, Ordering::Relaxed);
+                    next_price[shard_idx].store(p, Ordering::Relaxed);
+                    black_box(book.best_bid());
+                });
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, throughput_sharded_book_push);
+criterion_main!(benches);

--- a/tests/matching_engine.rs
+++ b/tests/matching_engine.rs
@@ -22,6 +22,8 @@ fn cargo_toml_lists_bench_targets() {
         "integrity_stress",
         "observability_overhead",
         "parallel_best_quotes",
+        "throughput_sharded_add",
+        "throughput_sharded_book_push",
     ] {
         assert!(
             cargo.contains(name),


### PR DESCRIPTION
Closes #12.

## Summary
Adds two sharded / multi-book benchmarks to measure **aggregate** ops/sec across cores:
- `throughput_sharded_add`: add-only across shard-local engines (`harness` + `parallel`)
- `throughput_sharded_book_push`: parallel `PriceBook::push` (feature `parallel`) as an upper bound

## Notes
- Updates README with reference machine medians (Linux 6.5, rustc 1.94.1, i7-13650HX / 20 CPUs).
- Extends the bench-target guard test and wires `[[bench]]` entries.

## Gates
`make ci` and `make quality-gate` pass locally.