### PR TITLE
bench: sharded mixed routing with OrderId->shard index

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,3 +127,8 @@ required-features = ["harness", "parallel"]
 name = "throughput_sharded_book_push"
 harness = false
 required-features = ["parallel"]
+
+[[bench]]
+name = "throughput_sharded_mixed"
+harness = false
+required-features = ["harness", "parallel"]

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Disable harness: `omer = { version = "…", default-features = false }`.
 | `parallel_best_quotes` | `cargo bench -p omer --features parallel --bench parallel_best_quotes` | 256 `BTreeOrderBook` instances: sequential best-quote scan vs `par_best_quotes` |
 | `throughput_sharded_add` | `cargo bench -p omer --features harness,parallel --bench throughput_sharded_add` | Sharded add-only workload: one engine per shard, adds executed in parallel (`rayon`) |
 | `throughput_sharded_book_push` | `cargo bench -p omer --features parallel --bench throughput_sharded_book_push` | Sharded book-only `DashSkipOrderBook::push` in parallel; same-price FIFO vs distinct prices |
+| `throughput_sharded_mixed` | `cargo bench -p omer --features harness,parallel --bench throughput_sharded_mixed` | Sharded mixed flow with explicit `OrderId -> shard` index for cancel routing |
 | `itch_parse` | `cargo bench -p omer --bench itch_parse` | `scan_decode_book_messages` on 50k AddOrder packets in one buffer |
 | `micro` | `cargo bench -p omer --bench micro` | Near-no-op Criterion smoke (picosecond-scale; not engine work) |
 | `matching_engine`, `market_manager` | same pattern | ITCH-shaped smoke benches |
@@ -144,6 +145,7 @@ One **release** run on **Linux 6.5**, **rustc 1.94.1**, **Intel i7-13650HX (20 C
 | `parallel_best_quotes` / sequential vs `rayon` | **~710 ns vs ~19.9 µs** | 256 tiny books: parallel fork/join dominates; scale up book count or work per book to see win |
 | `throughput_sharded_add` / 20 shards add-only | **~19.1 Melem/s** | Aggregate across shards; still far from 1B ops/s without further batching/layout work |
 | `throughput_sharded_book_push` / 20 shards same-price FIFO | **~57.8 Melem/s** | Upper bound (book-only). Distinct prices median was **~23.8 Melem/s** |
+| `throughput_sharded_mixed` / 20 shards + `OrderId -> shard` index | **~2.09 Melem/s** | More realistic mixed path; routing lookups + mixed command costs are visible |
 
 `micro` / `matching_engine` / `market_manager` report **~210 ps** per iter (empty loops)—kept as compile/smoke anchors only.
 

--- a/benches/throughput_sharded_mixed.rs
+++ b/benches/throughput_sharded_mixed.rs
@@ -1,0 +1,159 @@
+//! Sharded mixed throughput with explicit `OrderId -> shard` routing.
+//!
+//! This models gateway-side routing for cancel-heavy flows:
+//! adds are routed by symbol/shard, and cancels use the routing index.
+
+use std::collections::{HashMap, VecDeque};
+use std::hint::black_box;
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use omer::engine::{
+    AddOrderCommand, CancelByOrderIdCommand, OrderCommand, OrderMatchingService,
+};
+use omer::harness::{
+    EngineWithBookNoOp, InMemoryPriceBook, engine_with_book_noop,
+};
+use omer::types::{OrderType, Side, TimeInForce};
+use rayon::prelude::*;
+
+const OPS_PER_SHARD: u64 = 20_000;
+
+type ShardEngine = EngineWithBookNoOp<InMemoryPriceBook>;
+type AliveQueues = Vec<VecDeque<u64>>;
+type RoutedBatches = Vec<Vec<OrderCommand>>;
+
+struct ShardedRouter {
+    engines: Vec<ShardEngine>,
+    order_to_shard: HashMap<u64, usize>,
+    alive_ids: AliveQueues,
+    next_order_id: u64,
+}
+
+impl ShardedRouter {
+    fn new(shards: usize) -> Self {
+        Self {
+            engines: (0..shards).map(|_| engine_with_book_noop()).collect(),
+            order_to_shard: HashMap::with_capacity(shards * 8_192),
+            alive_ids: (0..shards).map(|_| VecDeque::new()).collect(),
+            next_order_id: 1,
+        }
+    }
+
+    fn alloc_order_id(&mut self) -> u64 {
+        let id = self.next_order_id;
+        self.next_order_id = self.next_order_id.wrapping_add(1);
+        id
+    }
+
+    fn add_limit(
+        &mut self,
+        shard: usize,
+        side: Side,
+        qty: i64,
+        price: i64,
+        batches: &mut RoutedBatches,
+    ) {
+        let id = self.alloc_order_id();
+        self.order_to_shard.insert(id, shard);
+        self.alive_ids[shard].push_back(id);
+
+        batches[shard].push(OrderCommand::Add(AddOrderCommand {
+            id,
+            participant_id: 100 + shard as u64,
+            symbol_id: shard as u32 + 1,
+            side,
+            order_type: OrderType::Limit,
+            price: Some(price),
+            quantity: qty,
+            time_in_force: TimeInForce::Gtc,
+            stop_price: None,
+            max_visible_quantity: None,
+            slippage: None,
+            trailing_distance: None,
+            trailing_step: None,
+        }));
+    }
+
+    fn add_market(
+        &mut self,
+        shard: usize,
+        side: Side,
+        qty: i64,
+        batches: &mut RoutedBatches,
+    ) {
+        let id = self.alloc_order_id();
+        batches[shard].push(OrderCommand::Add(AddOrderCommand {
+            id,
+            participant_id: 200 + shard as u64,
+            symbol_id: shard as u32 + 1,
+            side,
+            order_type: OrderType::Market,
+            price: None,
+            quantity: qty,
+            time_in_force: TimeInForce::Ioc,
+            stop_price: None,
+            max_visible_quantity: None,
+            slippage: None,
+            trailing_distance: None,
+            trailing_step: None,
+        }));
+    }
+
+    fn cancel_oldest(&mut self, shard: usize, batches: &mut RoutedBatches) {
+        if let Some(order_id) = self.alive_ids[shard].pop_front()
+            && self.order_to_shard.remove(&order_id).is_some()
+        {
+            batches[shard].push(OrderCommand::CancelByOrderId(
+                CancelByOrderIdCommand { order_id },
+            ));
+        }
+    }
+
+    fn run_round(&mut self) {
+        let shards = self.engines.len();
+        let mut batches: RoutedBatches = vec![Vec::<OrderCommand>::new(); shards];
+
+        for shard in 0..shards {
+            for i in 0..OPS_PER_SHARD {
+                match i % 10 {
+                    0..=5 => {
+                        let p = 100 + ((i as i64 + shard as i64) % 80);
+                        self.add_limit(shard, Side::Buy, 1, p, &mut batches);
+                    }
+                    6 | 7 => self.cancel_oldest(shard, &mut batches),
+                    8 => self.add_limit(shard, Side::Sell, 5, 250, &mut batches),
+                    _ => self.add_market(shard, Side::Buy, 5, &mut batches),
+                }
+            }
+        }
+
+        self.engines
+            .par_iter_mut()
+            .zip(batches.into_par_iter())
+            .for_each(|(engine, cmds)| {
+                for cmd in cmds {
+                    let _ = engine.process(cmd);
+                }
+                black_box((engine.best_bid(), engine.best_ask()));
+            });
+    }
+}
+
+fn throughput_sharded_mixed(c: &mut Criterion) {
+    let shards = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+    let mut router = ShardedRouter::new(shards);
+
+    let mut group = c.benchmark_group("throughput_sharded_mixed");
+    group.throughput(Throughput::Elements(OPS_PER_SHARD * shards as u64));
+    group.bench_function("order_id_indexed_add_cancel_market", |b| {
+        b.iter(|| {
+            router.run_round();
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(benches, throughput_sharded_mixed);
+criterion_main!(benches);

--- a/tests/matching_engine.rs
+++ b/tests/matching_engine.rs
@@ -24,6 +24,7 @@ fn cargo_toml_lists_bench_targets() {
         "parallel_best_quotes",
         "throughput_sharded_add",
         "throughput_sharded_book_push",
+        "throughput_sharded_mixed",
     ] {
         assert!(
             cargo.contains(name),


### PR DESCRIPTION
Closes #14.

## Summary
- Adds throughput_sharded_mixed: mixed add/cancel/market workload across shard-local engines.
- Uses an explicit OrderId-to-shard map so cancels route without scanning shards.
- Routes work into per-shard command batches, then executes shards in parallel with rayon.
- Updates README benchmark table and observed values in plain English.

## Verification
- make ci passed locally.
- make quality-gate passed locally.
- Quick benchmark run (Criterion short sampling): throughput_sharded_mixed median throughput about 2.09 Melem/s on the reference machine.