### PR TITLE
test: replace weak metadata checks with behavioral tests

### DIFF
--- a/tests/market_manager.rs
+++ b/tests/market_manager.rs
@@ -1,26 +1,92 @@
-//! **MarketManager** / multi-instrument scenarios are not implemented in this crate yet.
-//! This test only checks that `benches/PLAN.md` still lists the planned keywords.
+//! Integration checks for ITCH-style command variants used by higher-level market orchestration.
+
+use omer::book::service::BTreeOrderBook;
+use omer::engine::{
+    AddOrderCommand, ExecuteOrderCommand, OrderCommand, OrderMatchingEngine,
+    OrderMatchingService, ReduceOrderCommand, ReplaceOrderByNewIdCommand,
+};
+use omer::events::NoOpEventSink;
+use omer::matching::PriceCrossMatchingPolicy;
+use omer::self_trade::AllowAllSelfTradePolicy;
+use omer::sequence::CounterSequenceGenerator;
+use omer::store::service::HashMapOrderStore;
+use omer::types::{OrderType, Side, TimeInForce};
+
+type TestEngine = OrderMatchingEngine<
+    CounterSequenceGenerator,
+    BTreeOrderBook,
+    HashMapOrderStore,
+    PriceCrossMatchingPolicy,
+    AllowAllSelfTradePolicy,
+    NoOpEventSink,
+>;
+
+fn new_engine() -> TestEngine {
+    OrderMatchingEngine::new(
+        CounterSequenceGenerator::new(),
+        BTreeOrderBook::new(),
+        HashMapOrderStore::new(),
+        PriceCrossMatchingPolicy,
+        AllowAllSelfTradePolicy,
+        NoOpEventSink,
+    )
+}
 
 #[test]
-fn bench_plan_covers_latency_and_scenario_backlog() {
-    let plan =
-        include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/benches/PLAN.md"));
-    for needle in [
-        "latency_add",
-        "throughput_mixed",
-        "correctness",
-        "multi-instrument",
-        "IOC",
-        "FOK",
-        "AON",
-        "iceberg",
-        "stop-limit",
-        "trailing",
-        "MarketManager",
-    ] {
-        assert!(
-            plan.contains(needle),
-            "benches/PLAN.md should mention `{needle}` for traceability"
-        );
-    }
+fn itch_style_reduce_execute_and_replace_by_new_id_flow() {
+    let mut engine = new_engine();
+
+    let add = AddOrderCommand {
+        id: 10,
+        participant_id: 100,
+        symbol_id: 1,
+        side: Side::Buy,
+        order_type: OrderType::Limit,
+        price: Some(101),
+        quantity: 10,
+        time_in_force: TimeInForce::Gtc,
+        stop_price: None,
+        max_visible_quantity: None,
+        slippage: None,
+        trailing_distance: None,
+        trailing_step: None,
+    };
+
+    assert!(engine.process(OrderCommand::Add(add)).is_ok());
+    assert_eq!(engine.best_bid(), Some(101));
+
+    assert!(
+        engine
+            .process(OrderCommand::Reduce(ReduceOrderCommand {
+                order_id: 10,
+                quantity: 3,
+            }))
+            .is_ok()
+    );
+    assert_eq!(engine.best_bid(), Some(101));
+
+    assert!(
+        engine
+            .process(OrderCommand::ReplaceByNewId(ReplaceOrderByNewIdCommand {
+                old_order_id: 10,
+                new_order_id: 11,
+                new_price: 102,
+                new_quantity: 4,
+                symbol_id: Some(1),
+                side: Some(Side::Buy),
+            }))
+            .is_ok()
+    );
+    assert_eq!(engine.best_bid(), Some(102));
+
+    assert!(
+        engine
+            .process(OrderCommand::Execute(ExecuteOrderCommand {
+                order_id: 11,
+                quantity: 4,
+            }))
+            .is_ok()
+    );
+    assert_eq!(engine.best_bid(), None);
+    assert_eq!(engine.best_ask(), None);
 }

--- a/tests/matching_engine.rs
+++ b/tests/matching_engine.rs
@@ -1,43 +1,93 @@
-//! Deep ITCH fixture coverage and end-to-end matching throughput are still growing.
-//! These tests only guard that ITCH/matching bench targets stay registered in `Cargo.toml` and README.
+//! Integration checks for batch processing behavior on `OrderMatchingEngine`.
 
-#[test]
-fn cargo_toml_lists_bench_targets() {
-    let cargo = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml"));
-    for name in [
-        "matching_engine",
-        "micro",
-        "market_manager",
-        "latency_add",
-        "latency_cancel",
-        "latency_replace",
-        "latency_market",
-        "itch_parse",
-        "throughput_book",
-        "throughput_engine",
-        "throughput_mixed",
-        "throughput_adversarial",
-        "correctness",
-        "memory_hot_path",
-        "integrity_stress",
-        "observability_overhead",
-        "parallel_best_quotes",
-        "throughput_sharded_add",
-        "throughput_sharded_book_push",
-        "throughput_sharded_mixed",
-    ] {
-        assert!(
-            cargo.contains(name),
-            "Cargo.toml should keep [[bench]] entry for {name}"
-        );
+use omer::book::service::BTreeOrderBook;
+use omer::engine::{AddOrderCommand, OrderCommand, OrderMatchingEngine};
+use omer::events::NoOpEventSink;
+use omer::matching::PriceCrossMatchingPolicy;
+use omer::self_trade::AllowAllSelfTradePolicy;
+use omer::sequence::CounterSequenceGenerator;
+use omer::store::service::HashMapOrderStore;
+use omer::types::{OrderType, Side, TimeInForce};
+
+type TestEngine = OrderMatchingEngine<
+    CounterSequenceGenerator,
+    BTreeOrderBook,
+    HashMapOrderStore,
+    PriceCrossMatchingPolicy,
+    AllowAllSelfTradePolicy,
+    NoOpEventSink,
+>;
+
+fn new_engine() -> TestEngine {
+    OrderMatchingEngine::new(
+        CounterSequenceGenerator::new(),
+        BTreeOrderBook::new(),
+        HashMapOrderStore::new(),
+        PriceCrossMatchingPolicy,
+        AllowAllSelfTradePolicy,
+        NoOpEventSink,
+    )
+}
+
+fn add_limit(id: u64, side: Side, price: i64, qty: i64) -> AddOrderCommand {
+    AddOrderCommand {
+        id,
+        participant_id: 100,
+        symbol_id: 1,
+        side,
+        order_type: OrderType::Limit,
+        price: Some(price),
+        quantity: qty,
+        time_in_force: TimeInForce::Gtc,
+        stop_price: None,
+        max_visible_quantity: None,
+        slippage: None,
+        trailing_distance: None,
+        trailing_step: None,
     }
 }
 
 #[test]
-fn readme_documents_itch_entry_point() {
-    let readme = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"));
-    assert!(
-        readme.contains("itch") || readme.contains("ITCH"),
-        "README should mention the ITCH module"
-    );
+fn process_batch_stops_on_first_error_and_keeps_prior_commits() {
+    let mut engine = new_engine();
+    let cmds = vec![
+        OrderCommand::Add(add_limit(1, Side::Buy, 100, 10)),
+        // Invalid: market order with an explicit price should be rejected.
+        OrderCommand::Add(AddOrderCommand {
+            id: 2,
+            participant_id: 100,
+            symbol_id: 1,
+            side: Side::Buy,
+            order_type: OrderType::Market,
+            price: Some(101),
+            quantity: 1,
+            time_in_force: TimeInForce::Ioc,
+            stop_price: None,
+            max_visible_quantity: None,
+            slippage: None,
+            trailing_distance: None,
+            trailing_step: None,
+        }),
+        OrderCommand::Add(add_limit(3, Side::Buy, 99, 5)),
+    ];
+
+    assert!(engine.process_batch(cmds).is_err());
+    assert_eq!(engine.best_bid(), Some(100));
+    assert_eq!(engine.best_ask(), None);
+}
+
+#[test]
+fn process_batch_applies_mixed_commands_in_order() {
+    let mut engine = new_engine();
+    let cmds = vec![
+        OrderCommand::Add(add_limit(10, Side::Buy, 101, 4)),
+        OrderCommand::CancelByOrderId(omer::engine::CancelByOrderIdCommand {
+            order_id: 10,
+        }),
+        OrderCommand::Add(add_limit(11, Side::Sell, 105, 2)),
+    ];
+
+    assert!(engine.process_batch(cmds).is_ok());
+    assert_eq!(engine.best_bid(), None);
+    assert_eq!(engine.best_ask(), Some(105));
 }


### PR DESCRIPTION
Closes #16.

## Summary
- Replaces low-signal integration tests that only checked strings in Cargo.toml, README, and benches PLAN.
- Adds stronger behavior checks in tests/matching_engine.rs:
  - process_batch stops on first error while keeping prior commits.
  - process_batch applies mixed commands in deterministic order.
- Adds ITCH-style lifecycle check in tests/market_manager.rs:
  - add -> reduce -> replace_by_new_id -> execute, with top-of-book assertions.

## Verification
- make ci passed locally.
- make quality-gate passed locally.