### PR TITLE
perf: index in-memory remove hot path

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,45 @@ One **release** run on **Linux 6.5**, **rustc 1.94.1**, **Intel i7-13650HX (20 C
 
 `micro` / `matching_engine` / `market_manager` report **~210 ps** per iter (empty loops)—kept as compile/smoke anchors only.
 
+### Flamegraph priority rollout log (ordered steps)
+
+Baseline commands used before Priority 1 (kept fixed for comparison):
+
+- `cargo bench --features harness,parallel --bench throughput_sharded_mixed -- --sample-size 10 --warm-up-time 1 --measurement-time 3`
+- `cargo bench --bench lock_read_heavy -- --sample-size 10 --warm-up-time 1 --measurement-time 3`
+
+Baseline medians from those commands:
+
+- `throughput_sharded_mixed`: about **470,480 operations per second**
+- `lock_read_heavy`:
+  - `std::sync::RwLock`: about **59,177,000 operations per second**
+  - `parking_lot::RwLock`: about **52,860,000 operations per second**
+  - `tokio::sync::RwLock`: about **24,760,000 operations per second**
+
+#### Priority 1 result: indexed remove in `InMemoryPriceBook`
+
+- Before: about **470,480 operations per second** (`throughput_sharded_mixed`)
+- After: about **2,446,400 operations per second** (`throughput_sharded_mixed`)
+- Relative change: roughly **5.2x higher throughput**
+
+What we tried:
+
+- Added an internal `order_id -> (side, price)` index in the harness in-memory book.
+- Kept public `PriceBook` behavior and trait interface unchanged.
+
+What worked:
+
+- `remove` now looks up the target level directly and scans one queue instead of all book levels.
+- Hot path throughput improved strongly on the sharded mixed workload.
+
+What did not work:
+
+- Nothing functionally regressed in tests, but this does not remove the per-level queue scan yet (`VecDeque::position` is still linear within one price level).
+
+Tradeoffs:
+
+- Slightly more memory and write-time bookkeeping (maintaining the index) in exchange for much faster cancel/remove routing in mixed workloads.
+
 ---
 
 ## Tokio harness binaries

--- a/src/harness/memory.rs
+++ b/src/harness/memory.rs
@@ -15,6 +15,7 @@ type PriceLevel = BTreeMap<Price, VecDeque<(OrderId, Sequence)>>;
 pub struct InMemoryPriceBook {
     bids: PriceLevel,
     asks: PriceLevel,
+    order_index: HashMap<OrderId, (Side, Price)>,
 }
 
 impl InMemoryPriceBook {
@@ -25,6 +26,7 @@ impl InMemoryPriceBook {
         time_priority: Sequence,
         bids: &mut PriceLevel,
         asks: &mut PriceLevel,
+        order_index: &mut HashMap<OrderId, (Side, Price)>,
     ) {
         match side {
             Side::Buy => bids
@@ -36,12 +38,14 @@ impl InMemoryPriceBook {
                 .or_default()
                 .push_back((order_id, time_priority)),
         }
+        order_index.insert(order_id, (side, price));
     }
 
     fn pop_best_side(
         side: Side,
         bids: &mut PriceLevel,
         asks: &mut PriceLevel,
+        order_index: &mut HashMap<OrderId, (Side, Price)>,
     ) -> Option<OrderId> {
         let (best_price, q) = match side {
             Side::Buy => {
@@ -71,26 +75,52 @@ impl InMemoryPriceBook {
                 }
             }
         }
+        order_index.remove(&order_id);
         Some(order_id)
+    }
+
+    fn remove_from_level(
+        order_id: &OrderId,
+        side: Side,
+        price: Price,
+        bids: &mut PriceLevel,
+        asks: &mut PriceLevel,
+    ) -> bool {
+        let levels = match side {
+            Side::Buy => bids,
+            Side::Sell => asks,
+        };
+        let should_remove_level = if let Some(q) = levels.get_mut(&price) {
+            if let Some(pos) = q.iter().position(|(id, _)| id == order_id) {
+                q.remove(pos).unwrap();
+                q.is_empty()
+            } else {
+                return false;
+            }
+        } else {
+            return false;
+        };
+        if should_remove_level {
+            levels.remove(&price);
+        }
+        true
     }
 
     fn remove_from_side(
         order_id: &OrderId,
         bids: &mut PriceLevel,
         asks: &mut PriceLevel,
+        order_index: &mut HashMap<OrderId, (Side, Price)>,
     ) -> bool {
-        for q in bids.values_mut() {
-            if let Some(pos) = q.iter().position(|(id, _)| id == order_id) {
-                q.remove(pos).unwrap();
-                return true;
-            }
+        let Some((side, price)) = order_index.remove(order_id) else {
+            return false;
+        };
+        if Self::remove_from_level(order_id, side, price, bids, asks) {
+            return true;
         }
-        for q in asks.values_mut() {
-            if let Some(pos) = q.iter().position(|(id, _)| id == order_id) {
-                q.remove(pos).unwrap();
-                return true;
-            }
-        }
+
+        // Keep behavior stable if index and queues drift apart unexpectedly.
+        order_index.insert(*order_id, (side, price));
         false
     }
 }
@@ -118,15 +148,26 @@ impl PriceBook for InMemoryPriceBook {
             time_priority,
             &mut self.bids,
             &mut self.asks,
+            &mut self.order_index,
         );
     }
 
     fn pop_best(&mut self, side: Side) -> Option<OrderId> {
-        Self::pop_best_side(side, &mut self.bids, &mut self.asks)
+        Self::pop_best_side(
+            side,
+            &mut self.bids,
+            &mut self.asks,
+            &mut self.order_index,
+        )
     }
 
     fn remove(&mut self, order_id: &OrderId) -> bool {
-        Self::remove_from_side(order_id, &mut self.bids, &mut self.asks)
+        Self::remove_from_side(
+            order_id,
+            &mut self.bids,
+            &mut self.asks,
+            &mut self.order_index,
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- add `order_id -> (side, price)` indexing to `InMemoryPriceBook` so remove operations target one level instead of scanning all levels
- rerun fixed-argument baseline benchmark and record before/after values in README using plain English units
- document what was tried, what worked, what did not, and tradeoffs for priority 1

## Test plan
- [x] make ci
- [x] make quality-gate
- [x] cargo bench --features harness,parallel --bench throughput_sharded_mixed -- --sample-size 10 --warm-up-time 1 --measurement-time 3

Closes #20