### PR TITLE
perf: reduce sharded routing lookup overhead

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,29 @@ Tradeoffs:
 
 - Slightly more memory and write-time bookkeeping (maintaining the index) in exchange for much faster cancel/remove routing in mixed workloads.
 
+#### Priority 2 result: reduce routing/index lookup overhead
+
+- Before: about **2,446,400 operations per second** (`throughput_sharded_mixed`, after Priority 1)
+- After: about **2,043,200 operations per second**
+- Relative change: roughly **16% lower throughput** in this short run (Criterion reported no statistically significant change)
+
+What we tried:
+
+- Removed an unnecessary map-presence check in the sharded mixed benchmark cancel path.
+- Changed server cancel routing from `read + get` to a single `write + remove` pass, which also cleans up stale route entries.
+
+What worked:
+
+- Server-side cancel routing is now cleaner and does one map operation while removing canceled IDs from the route index.
+
+What did not work:
+
+- This isolated step did not produce a clear throughput gain in the benchmark; measured result trended lower in this sample window.
+
+Tradeoffs:
+
+- Better route-index lifecycle behavior and simpler fast path, but no immediate benchmark win at this sampling depth.
+
 ---
 
 ## Tokio harness binaries

--- a/benches/throughput_sharded_mixed.rs
+++ b/benches/throughput_sharded_mixed.rs
@@ -100,9 +100,8 @@ impl ShardedRouter {
     }
 
     fn cancel_oldest(&mut self, shard: usize, batches: &mut RoutedBatches) {
-        if let Some(order_id) = self.alive_ids[shard].pop_front()
-            && self.order_to_shard.remove(&order_id).is_some()
-        {
+        if let Some(order_id) = self.alive_ids[shard].pop_front() {
+            self.order_to_shard.remove(&order_id);
             batches[shard].push(OrderCommand::CancelByOrderId(
                 CancelByOrderIdCommand { order_id },
             ));

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -151,7 +151,7 @@ async fn route_and_dispatch(
             Ok(RouteResult::Ok)
         }
         WireCmd::CancelById(order_id) => {
-            let route = index.read().await.get(&order_id).copied();
+            let route = index.write().await.remove(&order_id);
             if let Some(shard) = route {
                 let _ = senders[shard].send(WorkerCmd::CancelById(
                     CancelByOrderIdCommand { order_id },


### PR DESCRIPTION
## Summary
- remove avoidable route-index checks in sharded mixed benchmark cancel path
- use single `remove` routing operation for server-side `CANCELID` handling
- record priority 2 benchmark result and plain-English notes in README

## Test plan
- [x] make ci
- [x] make quality-gate
- [x] cargo bench --features harness,parallel --bench throughput_sharded_mixed -- --sample-size 10 --warm-up-time 1 --measurement-time 3

Closes #22