### PR TITLE
bench: compare sharded mixed across book backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Disable harness: `omer = { version = "…", default-features = false }`.
 | `parallel_best_quotes` | `cargo bench -p omer --features parallel --bench parallel_best_quotes` | 256 `BTreeOrderBook` instances: sequential best-quote scan vs `par_best_quotes` |
 | `throughput_sharded_add` | `cargo bench -p omer --features harness,parallel --bench throughput_sharded_add` | Sharded add-only workload: one engine per shard, adds executed in parallel (`rayon`) |
 | `throughput_sharded_book_push` | `cargo bench -p omer --features parallel --bench throughput_sharded_book_push` | Sharded book-only `DashSkipOrderBook::push` in parallel; same-price FIFO vs distinct prices |
-| `throughput_sharded_mixed` | `cargo bench -p omer --features harness,parallel --bench throughput_sharded_mixed` | Sharded mixed flow with explicit `OrderId -> shard` index for cancel routing |
+| `throughput_sharded_mixed` | `cargo bench -p omer --features harness,parallel --bench throughput_sharded_mixed` | Sharded mixed flow with explicit `OrderId -> shard` index for cancel routing, measured on `InMemoryPriceBook`, `BTreeOrderBook`, and `DashSkipOrderBook` |
 | `lock_read_heavy` | `cargo bench -p omer --bench lock_read_heavy` | Read-heavy lock comparison: `Arc<std::sync::RwLock<_>>` vs `Arc<parking_lot::RwLock<_>>` vs `Arc<tokio::sync::RwLock<_>>` |
 | `itch_parse` | `cargo bench -p omer --bench itch_parse` | `scan_decode_book_messages` on 50k AddOrder packets in one buffer |
 | `micro` | `cargo bench -p omer --bench micro` | Near-no-op Criterion smoke (picosecond-scale; not engine work) |
@@ -235,6 +235,31 @@ What did not work:
 Tradeoffs:
 
 - Better route-index lifecycle behavior and simpler fast path, but no immediate benchmark win at this sampling depth.
+
+#### Priority 3 result: sharded mixed benchmark on multiple backends
+
+Median throughput from the same fixed benchmark command:
+
+- `InMemoryPriceBook`: about **2,379,900 operations per second**
+- `BTreeOrderBook`: about **1,565,500 operations per second**
+- `DashSkipOrderBook`: about **1,587,900 operations per second**
+
+What we tried:
+
+- Generalized the sharded mixed benchmark to run the same workload against three book backends.
+
+What worked:
+
+- We now get direct backend-to-backend numbers under one benchmark harness and one command.
+- The in-memory harness backend remained the fastest in this mixed test shape.
+
+What did not work:
+
+- This step is measurement-focused; it does not by itself improve throughput.
+
+Tradeoffs:
+
+- Longer benchmark runtime (three benchmark functions instead of one) in exchange for clearer backend parity data.
 
 ---
 

--- a/benches/throughput_sharded_mixed.rs
+++ b/benches/throughput_sharded_mixed.rs
@@ -6,7 +6,11 @@
 use std::collections::{HashMap, VecDeque};
 use std::hint::black_box;
 
-use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use criterion::{
+    BenchmarkId, Criterion, Throughput, criterion_group, criterion_main,
+};
+use omer::book::PriceBook;
+use omer::book::service::{BTreeOrderBook, DashSkipOrderBook};
 use omer::engine::{
     AddOrderCommand, CancelByOrderIdCommand, OrderCommand, OrderMatchingService,
 };
@@ -18,21 +22,22 @@ use rayon::prelude::*;
 
 const OPS_PER_SHARD: u64 = 20_000;
 
-type ShardEngine = EngineWithBookNoOp<InMemoryPriceBook>;
 type AliveQueues = Vec<VecDeque<u64>>;
 type RoutedBatches = Vec<Vec<OrderCommand>>;
+type ShardEngine<PB> = EngineWithBookNoOp<PB>;
 
-struct ShardedRouter {
-    engines: Vec<ShardEngine>,
+#[allow(clippy::type_complexity)]
+struct ShardedRouter<PB: PriceBook + Default + Send> {
+    engines: Vec<ShardEngine<PB>>,
     order_to_shard: HashMap<u64, usize>,
     alive_ids: AliveQueues,
     next_order_id: u64,
 }
 
-impl ShardedRouter {
+impl<PB: PriceBook + Default + Send> ShardedRouter<PB> {
     fn new(shards: usize) -> Self {
         Self {
-            engines: (0..shards).map(|_| engine_with_book_noop()).collect(),
+            engines: (0..shards).map(|_| engine_with_book_noop::<PB>()).collect(),
             order_to_shard: HashMap::with_capacity(shards * 8_192),
             alive_ids: (0..shards).map(|_| VecDeque::new()).collect(),
             next_order_id: 1,
@@ -138,19 +143,33 @@ impl ShardedRouter {
     }
 }
 
+fn bench_backend<PB: PriceBook + Default + Send + 'static>(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    backend_name: &str,
+    shards: usize,
+) {
+    let mut router = ShardedRouter::<PB>::new(shards);
+    group.bench_with_input(
+        BenchmarkId::new("order_id_indexed_add_cancel_market", backend_name),
+        &backend_name,
+        |b, _| {
+            b.iter(|| {
+                router.run_round();
+            });
+        },
+    );
+}
+
 fn throughput_sharded_mixed(c: &mut Criterion) {
     let shards = std::thread::available_parallelism()
         .map(|n| n.get())
         .unwrap_or(1);
-    let mut router = ShardedRouter::new(shards);
 
     let mut group = c.benchmark_group("throughput_sharded_mixed");
     group.throughput(Throughput::Elements(OPS_PER_SHARD * shards as u64));
-    group.bench_function("order_id_indexed_add_cancel_market", |b| {
-        b.iter(|| {
-            router.run_round();
-        });
-    });
+    bench_backend::<InMemoryPriceBook>(&mut group, "inmemory", shards);
+    bench_backend::<BTreeOrderBook>(&mut group, "btree", shards);
+    bench_backend::<DashSkipOrderBook>(&mut group, "dash_skip", shards);
     group.finish();
 }
 


### PR DESCRIPTION
## Summary
- generalize `throughput_sharded_mixed` to run identical mixed workload on in-memory, btree, and dash-skip price books
- keep the same command arguments for fair comparison across backends
- update README with plain-English backend comparison values and rollout notes

## Test plan
- [x] make ci
- [x] make quality-gate
- [x] cargo bench --features harness,parallel --bench throughput_sharded_mixed -- --sample-size 10 --warm-up-time 1 --measurement-time 3

Closes #24