### PR TITLE
feat: p1 distributed multi-instrument gateway foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,20 +341,44 @@ Tradeoffs:
 
 - Cleaner flamegraphs require stricter run conditions (core pinning, fewer background tasks), which can make absolute throughput values from that run less representative of normal multi-core throughput.
 
+#### Priority 6 result: distributed multi-instrument protocol foundation (`p1`)
+
+What we tried:
+
+- Introduced a shared typed wire protocol module in `src/distributed_wire.rs` used by both harness binaries.
+- Added explicit instrument-aware routing in the server with one matcher worker per instrument (`--instruments`, default 4).
+- Switched client emission to instrument-aware frames with configurable batch size (`--batch-size`) and optional `BATCH` line frames.
+
+What worked:
+
+- Gateway parse/validation now rejects malformed lines and invalid instrument IDs before dispatch.
+- Routing is deterministic (`instrument_id -> dedicated worker`) and cancel commands validate route consistency (`order_id` index + instrument match).
+- Matcher boundary checks ensure worker and command instrument IDs align before processing.
+
+What did not work:
+
+- This step establishes architecture/validation boundaries only; no throughput tuning was targeted in this priority.
+- Legacy ad-hoc line parsing path was removed, so older `CANCELID <order_id>` payloads must include instrument (`CANCELID <order_id> <instrument_id>`).
+
+Tradeoffs:
+
+- More protocol strictness and explicit routing metadata improve correctness and diagnosability, at the cost of slightly more wire payload and parsing logic.
+
 ---
 
 ## Tokio harness binaries
 
-This repo now includes a lightweight benchmark harness server and client:
+This repo includes a lightweight benchmark harness server and client:
 
-- `cargo run --bin server -- --bind 127.0.0.1:7001 --shards 8`
-- `cargo run --bin client -- --addr 127.0.0.1:7001 --connections 4 --symbols 32 --duration-secs 8`
+- `cargo run --bin server -- --bind 127.0.0.1:7001 --instruments 4`
+- `cargo run --bin client -- --addr 127.0.0.1:7001 --connections 4 --instruments 4 --batch-size 4 --duration-secs 8`
 
-Protocol is intentionally simple for measurement (not production API):
+Protocol is intentionally compact for measurement (not production API):
 
-- `ADD <id> <participant> <symbol> <B|S> <price> <qty>`
-- `MARKET <id> <participant> <symbol> <B|S> <qty>`
-- `CANCELID <order_id>`
+- `ADD <id> <participant> <instrument> <B|S> <price> <qty>`
+- `MARKET <id> <participant> <instrument> <B|S> <qty>`
+- `CANCELID <order_id> <instrument>`
+- `BATCH <cmd1>|<cmd2>|...` (optional multi-command frame)
 
 Reference run on the same machine:
 

--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -7,6 +7,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use clap::Parser;
+use omer::distributed_wire::{WireCommand, WireFrame, encode_frame};
+use omer::types::Side;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
 
@@ -14,14 +16,24 @@ type DynErr = Box<dyn std::error::Error>;
 type TaskErr = Box<dyn std::error::Error + Send + Sync>;
 type Metrics = Arc<AtomicU64>;
 
+#[derive(Clone)]
+struct WorkerConfig {
+    addr: String,
+    instruments: u32,
+    batch_size: usize,
+    deadline: Instant,
+}
+
 #[derive(Parser, Debug)]
 struct Args {
     #[arg(long, default_value = "127.0.0.1:7001")]
     addr: String,
     #[arg(long, default_value_t = 4)]
     connections: usize,
-    #[arg(long, default_value_t = 1)]
-    symbols: u32,
+    #[arg(long, alias = "symbols", default_value_t = 4)]
+    instruments: u32,
+    #[arg(long, default_value_t = 4)]
+    batch_size: usize,
     #[arg(long, default_value_t = 10)]
     duration_secs: u64,
 }
@@ -36,15 +48,17 @@ async fn main() -> Result<(), DynErr> {
 
     let mut tasks = Vec::with_capacity(args.connections);
     for worker_id in 0..args.connections {
-        let addr = args.addr.clone();
+        let config = WorkerConfig {
+            addr: args.addr.clone(),
+            instruments: args.instruments.max(1),
+            batch_size: args.batch_size.max(1),
+            deadline,
+        };
         let ops = Arc::clone(&total_ops);
         let err = Arc::clone(&total_err);
         let lat = Arc::clone(&total_lat_nanos);
-        let symbols = args.symbols.max(1);
 
-        tasks.push(tokio::spawn(run_worker(
-            worker_id, addr, symbols, deadline, ops, err, lat,
-        )));
+        tasks.push(tokio::spawn(run_worker(worker_id, config, ops, err, lat)));
     }
 
     for t in tasks {
@@ -77,60 +91,94 @@ async fn main() -> Result<(), DynErr> {
 
 async fn run_worker(
     worker_id: usize,
-    addr: String,
-    symbols: u32,
-    deadline: Instant,
+    config: WorkerConfig,
     ok_ops: Metrics,
     err_ops: Metrics,
     total_lat_nanos: Metrics,
 ) -> Result<(), TaskErr> {
-    let stream = TcpStream::connect(&addr).await?;
+    let stream = TcpStream::connect(&config.addr).await?;
     let (read_half, mut write_half) = stream.into_split();
     let mut lines = BufReader::new(read_half).lines();
 
     let mut order_id = (worker_id as u64) * 1_000_000_000 + 1;
     let mut cancel_id: Option<u64> = None;
     let mut i = 0_u64;
-    while Instant::now() < deadline {
-        let line = workload_line(i, order_id, symbols, &mut cancel_id);
+    while Instant::now() < config.deadline {
+        let frame = workload_frame(
+            i,
+            order_id,
+            config.instruments,
+            config.batch_size,
+            &mut cancel_id,
+        );
+        let line = encode_frame(&frame)?;
+        let frame_len = frame.commands.len() as u64;
         let t0 = Instant::now();
         write_half.write_all(line.as_bytes()).await?;
         match lines.next_line().await? {
             Some(resp) if resp.starts_with("OK") => {
-                ok_ops.fetch_add(1, Ordering::Relaxed);
+                ok_ops.fetch_add(frame_len, Ordering::Relaxed);
                 total_lat_nanos
                     .fetch_add(t0.elapsed().as_nanos() as u64, Ordering::Relaxed);
             }
             Some(_) | None => {
-                err_ops.fetch_add(1, Ordering::Relaxed);
+                err_ops.fetch_add(frame_len, Ordering::Relaxed);
             }
         }
-        order_id = order_id.wrapping_add(1);
-        i = i.wrapping_add(1);
+        order_id = order_id.wrapping_add(frame_len);
+        i = i.wrapping_add(frame_len);
     }
     Ok(())
 }
 
-fn workload_line(
+fn workload_frame(
     i: u64,
     order_id: u64,
-    symbols: u32,
+    instruments: u32,
+    batch_size: usize,
     cancel_id: &mut Option<u64>,
-) -> String {
-    let symbol = (order_id as u32 % symbols) + 1;
-    match i % 10 {
-        0..=5 => {
-            *cancel_id = Some(order_id);
-            format!(
-                "ADD {order_id} 100 {symbol} B {} 1\n",
-                100 + (order_id as i64 % 50)
-            )
-        }
-        6 | 7 => {
-            let oid = cancel_id.unwrap_or(order_id);
-            format!("CANCELID {oid}\n")
-        }
-        8 => format!("ADD {order_id} 101 {symbol} S 250 5\n"),
-        _ => format!("MARKET {order_id} 102 {symbol} B 5\n"),
+) -> WireFrame {
+    let mut commands = Vec::with_capacity(batch_size);
+    for offset in 0..batch_size {
+        let current = order_id.wrapping_add(offset as u64);
+        let seq = i.wrapping_add(offset as u64);
+        let instrument_id = (current as u32 % instruments) + 1;
+        let cmd = match seq % 10 {
+            0..=5 => {
+                *cancel_id = Some(current);
+                WireCommand::Add {
+                    id: current,
+                    participant_id: 100,
+                    instrument_id,
+                    side: Side::Buy,
+                    price: 100 + (current as i64 % 50),
+                    quantity: 1,
+                }
+            }
+            6 | 7 => {
+                let oid = cancel_id.unwrap_or(current);
+                WireCommand::CancelById {
+                    order_id: oid,
+                    instrument_id,
+                }
+            }
+            8 => WireCommand::Add {
+                id: current,
+                participant_id: 101,
+                instrument_id,
+                side: Side::Sell,
+                price: 250,
+                quantity: 5,
+            },
+            _ => WireCommand::Market {
+                id: current,
+                participant_id: 102,
+                instrument_id,
+                side: Side::Buy,
+                quantity: 5,
+            },
+        };
+        commands.push(cmd);
     }
+    WireFrame { commands }
 }

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -1,22 +1,19 @@
 //! Tokio benchmark harness server.
 //!
-//! Accepts a simple line protocol and routes commands to shard-local engines.
+//! Accepts a typed line protocol and routes commands to instrument-local engines.
 
 use std::collections::HashMap;
 use std::sync::Arc;
 
 use clap::Parser;
 use omer::book::service::BTreeOrderBook;
-use omer::engine::{
-    AddOrderCommand, CancelByOrderIdCommand, OrderCommand, OrderMatchingService,
-    builder,
-};
+use omer::distributed_wire::{RoutedCommand, WireParseError, parse_frame};
+use omer::engine::{OrderCommand, OrderMatchingService, builder};
 use omer::events::NoOpEventSink;
 use omer::matching::PriceCrossMatchingPolicy;
 use omer::self_trade::AllowAllSelfTradePolicy;
 use omer::sequence::CounterSequenceGenerator;
 use omer::store::service::HashMapOrderStore;
-use omer::types::{OrderType, Side, TimeInForce};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{RwLock, mpsc};
@@ -25,59 +22,38 @@ use tokio::sync::{RwLock, mpsc};
 struct Args {
     #[arg(long, default_value = "127.0.0.1:7001")]
     bind: String,
-    #[arg(long, default_value_t = 8)]
-    shards: usize,
+    #[arg(long, default_value_t = 4)]
+    instruments: usize,
 }
 
 #[derive(Debug)]
 enum WorkerCmd {
-    Add(AddOrderCommand),
-    CancelById(CancelByOrderIdCommand),
+    Add {
+        instrument_id: u32,
+        add: omer::engine::AddOrderCommand,
+    },
+    CancelById {
+        instrument_id: u32,
+        cancel: omer::engine::CancelByOrderIdCommand,
+    },
 }
 
 type RouterIndex = Arc<RwLock<HashMap<u64, usize>>>;
 type WorkerSender = mpsc::UnboundedSender<WorkerCmd>;
 type DynErr = Box<dyn std::error::Error>;
-type ParseErr = &'static str;
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<(), DynErr> {
     let args = Args::parse();
     let listener = TcpListener::bind(&args.bind).await?;
-    let shards = args.shards.max(1);
-
-    let mut senders = Vec::with_capacity(shards);
-    for shard_id in 0..shards {
-        let (tx, mut rx) = mpsc::unbounded_channel::<WorkerCmd>();
-        senders.push(tx);
-        tokio::spawn(async move {
-            let mut engine = builder()
-                .with_sequence_generator(CounterSequenceGenerator::new())
-                .with_price_book(BTreeOrderBook::new())
-                .with_order_store(HashMapOrderStore::new())
-                .with_matching_policy(PriceCrossMatchingPolicy)
-                .with_self_trade_policy(AllowAllSelfTradePolicy)
-                .with_event_sink(NoOpEventSink)
-                .build();
-
-            while let Some(cmd) = rx.recv().await {
-                match cmd {
-                    WorkerCmd::Add(add) => {
-                        let _ = engine.process(OrderCommand::Add(add));
-                    }
-                    WorkerCmd::CancelById(cancel) => {
-                        let _ =
-                            engine.process(OrderCommand::CancelByOrderId(cancel));
-                    }
-                }
-            }
-
-            eprintln!("worker {shard_id} exited");
-        });
-    }
+    let instruments = args.instruments.max(1);
+    let senders = build_worker_senders(instruments);
 
     let router_index: RouterIndex = Arc::new(RwLock::new(HashMap::new()));
-    println!("server listening on {}", args.bind);
+    println!(
+        "server listening on {} with instruments={}",
+        args.bind, instruments
+    );
 
     loop {
         let (stream, _) = listener.accept().await?;
@@ -96,14 +72,14 @@ async fn handle_client(
     senders: Vec<WorkerSender>,
     index: RouterIndex,
 ) -> Result<(), DynErr> {
-    let shards = senders.len();
+    let instruments = senders.len();
     let (read_half, mut write_half) = stream.into_split();
     let mut lines = BufReader::new(read_half).lines();
 
     while let Some(line) = lines.next_line().await? {
         write_response(
             &mut write_half,
-            route_and_dispatch(&line, shards, &senders, &index).await,
+            route_and_dispatch(&line, instruments, &senders, &index).await,
         )
         .await?;
     }
@@ -112,7 +88,7 @@ async fn handle_client(
 
 async fn write_response(
     writer: &mut tokio::net::tcp::OwnedWriteHalf,
-    result: Result<RouteResult, ParseErr>,
+    result: Result<RouteResult, WireParseError>,
 ) -> Result<(), DynErr> {
     match result {
         Ok(RouteResult::Ok) => writer.write_all(b"OK\n").await?,
@@ -131,113 +107,120 @@ enum RouteResult {
 
 async fn route_and_dispatch(
     line: &str,
-    shards: usize,
+    instruments: usize,
     senders: &[WorkerSender],
     index: &RouterIndex,
-) -> Result<RouteResult, ParseErr> {
-    match parse_command(line)? {
-        WireCmd::Add(add) => {
-            let shard = (add.symbol_id as usize) % shards;
-            index.write().await.insert(add.id, shard);
-            let _ = senders[shard].send(WorkerCmd::Add(add));
-            Ok(RouteResult::Ok)
+) -> Result<RouteResult, WireParseError> {
+    let frame = parse_frame(line)?;
+    for cmd in frame.commands {
+        let route =
+            dispatch_command(cmd.into_routed(), instruments, senders, index)
+                .await?;
+        if matches!(route, RouteResult::UnknownOrder) {
+            return Ok(RouteResult::UnknownOrder);
         }
-        WireCmd::Market(mut add) => {
-            let shard = (add.symbol_id as usize) % shards;
-            add.order_type = OrderType::Market;
-            add.price = None;
-            add.time_in_force = TimeInForce::Ioc;
-            let _ = senders[shard].send(WorkerCmd::Add(add));
-            Ok(RouteResult::Ok)
-        }
-        WireCmd::CancelById(order_id) => {
-            let route = index.write().await.remove(&order_id);
-            if let Some(shard) = route {
-                let _ = senders[shard].send(WorkerCmd::CancelById(
-                    CancelByOrderIdCommand { order_id },
-                ));
-                Ok(RouteResult::Ok)
-            } else {
-                Ok(RouteResult::UnknownOrder)
+    }
+    Ok(RouteResult::Ok)
+}
+
+fn build_worker_senders(instruments: usize) -> Vec<WorkerSender> {
+    let mut senders = Vec::with_capacity(instruments);
+    for worker_idx in 0..instruments {
+        let worker_instrument = (worker_idx + 1) as u32;
+        let (tx, mut rx) = mpsc::unbounded_channel::<WorkerCmd>();
+        senders.push(tx);
+        tokio::spawn(async move {
+            let mut engine = builder()
+                .with_sequence_generator(CounterSequenceGenerator::new())
+                .with_price_book(BTreeOrderBook::new())
+                .with_order_store(HashMapOrderStore::new())
+                .with_matching_policy(PriceCrossMatchingPolicy)
+                .with_self_trade_policy(AllowAllSelfTradePolicy)
+                .with_event_sink(NoOpEventSink)
+                .build();
+
+            while let Some(cmd) = rx.recv().await {
+                apply_worker_command(worker_instrument, &mut engine, cmd);
             }
+            eprintln!("worker {worker_instrument} exited");
+        });
+    }
+    senders
+}
+
+fn apply_worker_command(
+    worker_instrument: u32,
+    engine: &mut impl OrderMatchingService,
+    cmd: WorkerCmd,
+) {
+    match cmd {
+        WorkerCmd::Add { instrument_id, add }
+            if add.symbol_id == worker_instrument
+                && instrument_id == worker_instrument =>
+        {
+            let _ = engine.process(OrderCommand::Add(add));
+        }
+        WorkerCmd::CancelById {
+            instrument_id,
+            cancel,
+        } if instrument_id == worker_instrument => {
+            let _ = engine.process(OrderCommand::CancelByOrderId(cancel));
+        }
+        _ => {}
+    }
+}
+
+async fn dispatch_command(
+    cmd: RoutedCommand,
+    instruments: usize,
+    senders: &[WorkerSender],
+    index: &RouterIndex,
+) -> Result<RouteResult, WireParseError> {
+    match cmd {
+        RoutedCommand::Add { instrument_id, add } => {
+            let worker = route_worker(instrument_id, instruments)?;
+            index.write().await.insert(add.id, worker);
+            let _ = senders[worker].send(WorkerCmd::Add { instrument_id, add });
+            Ok(RouteResult::Ok)
+        }
+        RoutedCommand::CancelById {
+            instrument_id,
+            cancel,
+        } => {
+            dispatch_cancel(instrument_id, cancel, instruments, senders, index)
+                .await
         }
     }
 }
 
-enum WireCmd {
-    Add(AddOrderCommand),
-    Market(AddOrderCommand),
-    CancelById(u64),
-}
-
-fn parse_command(line: &str) -> Result<WireCmd, ParseErr> {
-    let parts: Vec<&str> = line.split_whitespace().collect();
-    if parts.is_empty() {
-        return Err("empty");
+async fn dispatch_cancel(
+    instrument_id: u32,
+    cancel: omer::engine::CancelByOrderIdCommand,
+    instruments: usize,
+    senders: &[WorkerSender],
+    index: &RouterIndex,
+) -> Result<RouteResult, WireParseError> {
+    let expected_worker = route_worker(instrument_id, instruments)?;
+    let route = index.write().await.remove(&cancel.order_id);
+    let Some(worker) = route else {
+        return Ok(RouteResult::UnknownOrder);
+    };
+    if worker != expected_worker {
+        return Ok(RouteResult::UnknownOrder);
     }
+    let _ = senders[worker].send(WorkerCmd::CancelById {
+        instrument_id,
+        cancel,
+    });
+    Ok(RouteResult::Ok)
+}
 
-    match parts[0] {
-        "ADD" if parts.len() == 7 => parse_add(parts.as_slice()),
-        "MARKET" if parts.len() == 6 => parse_market(parts.as_slice()),
-        "CANCELID" if parts.len() == 2 => {
-            let order_id = parts[1].parse().map_err(|_| "order_id")?;
-            Ok(WireCmd::CancelById(order_id))
-        }
-        _ => Err("unknown"),
+fn route_worker(
+    instrument_id: u32,
+    instruments: usize,
+) -> Result<usize, WireParseError> {
+    if instrument_id == 0 || (instrument_id as usize) > instruments {
+        return Err(WireParseError::InvalidInstrument);
     }
-}
-
-fn parse_side(s: &str) -> Result<Side, ParseErr> {
-    match s {
-        "B" | "BUY" => Ok(Side::Buy),
-        "S" | "SELL" => Ok(Side::Sell),
-        _ => Err("side"),
-    }
-}
-
-fn parse_add(parts: &[&str]) -> Result<WireCmd, ParseErr> {
-    let id = parts[1].parse().map_err(|_| "id")?;
-    let participant_id = parts[2].parse().map_err(|_| "pid")?;
-    let symbol_id = parts[3].parse().map_err(|_| "symbol")?;
-    let side = parse_side(parts[4])?;
-    let price = parts[5].parse().map_err(|_| "price")?;
-    let quantity = parts[6].parse().map_err(|_| "qty")?;
-    Ok(WireCmd::Add(AddOrderCommand {
-        id,
-        participant_id,
-        symbol_id,
-        side,
-        order_type: OrderType::Limit,
-        price: Some(price),
-        quantity,
-        time_in_force: TimeInForce::Gtc,
-        stop_price: None,
-        max_visible_quantity: None,
-        slippage: None,
-        trailing_distance: None,
-        trailing_step: None,
-    }))
-}
-
-fn parse_market(parts: &[&str]) -> Result<WireCmd, ParseErr> {
-    let id = parts[1].parse().map_err(|_| "id")?;
-    let participant_id = parts[2].parse().map_err(|_| "pid")?;
-    let symbol_id = parts[3].parse().map_err(|_| "symbol")?;
-    let side = parse_side(parts[4])?;
-    let quantity = parts[5].parse().map_err(|_| "qty")?;
-    Ok(WireCmd::Market(AddOrderCommand {
-        id,
-        participant_id,
-        symbol_id,
-        side,
-        order_type: OrderType::Market,
-        price: None,
-        quantity,
-        time_in_force: TimeInForce::Ioc,
-        stop_price: None,
-        max_visible_quantity: None,
-        slippage: None,
-        trailing_distance: None,
-        trailing_step: None,
-    }))
+    Ok((instrument_id - 1) as usize)
 }

--- a/src/distributed_wire.rs
+++ b/src/distributed_wire.rs
@@ -1,0 +1,396 @@
+//! Shared wire protocol for distributed benchmark binaries.
+//!
+//! This module defines a typed command representation and a compact text
+//! encoding used by both `src/bin/server.rs` and `src/bin/client.rs`.
+
+use std::fmt;
+
+use crate::engine::{AddOrderCommand, CancelByOrderIdCommand};
+use crate::types::{OrderType, Side, TimeInForce};
+
+/// Maximum commands accepted in one batch frame.
+pub const MAX_BATCH_COMMANDS: usize = 1024;
+
+/// Protocol-level command used on the gateway/client boundary.
+#[derive(Debug, Clone, PartialEq)]
+pub enum WireCommand {
+    /// Limit add command.
+    Add {
+        /// Order identifier.
+        id: u64,
+        /// Participant identifier.
+        participant_id: u64,
+        /// Destination instrument identifier.
+        instrument_id: u32,
+        /// Order side.
+        side: Side,
+        /// Limit price.
+        price: i64,
+        /// Order quantity.
+        quantity: i64,
+    },
+    /// Market order command.
+    Market {
+        /// Order identifier.
+        id: u64,
+        /// Participant identifier.
+        participant_id: u64,
+        /// Destination instrument identifier.
+        instrument_id: u32,
+        /// Order side.
+        side: Side,
+        /// Order quantity.
+        quantity: i64,
+    },
+    /// Cancel by order ID.
+    CancelById {
+        /// Order identifier to cancel.
+        order_id: u64,
+        /// Destination instrument identifier.
+        instrument_id: u32,
+    },
+}
+
+/// Parsed frame: either a single command or a command batch.
+#[derive(Debug, Clone, PartialEq)]
+pub struct WireFrame {
+    /// Commands in this frame. Never empty.
+    pub commands: Vec<WireCommand>,
+}
+
+/// Parse/validation errors returned by wire decoding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WireParseError {
+    /// Empty frame.
+    Empty,
+    /// Unknown command shape.
+    Unknown,
+    /// Invalid numeric token.
+    InvalidNumber,
+    /// Invalid side token.
+    InvalidSide,
+    /// Invalid batch shape.
+    InvalidBatch,
+    /// Batch exceeds configured limit.
+    BatchTooLarge,
+    /// Instrument ID is invalid.
+    InvalidInstrument,
+}
+
+impl fmt::Display for WireParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => write!(f, "empty"),
+            Self::Unknown => write!(f, "unknown"),
+            Self::InvalidNumber => write!(f, "invalid_number"),
+            Self::InvalidSide => write!(f, "invalid_side"),
+            Self::InvalidBatch => write!(f, "invalid_batch"),
+            Self::BatchTooLarge => write!(f, "batch_too_large"),
+            Self::InvalidInstrument => write!(f, "invalid_instrument"),
+        }
+    }
+}
+
+impl std::error::Error for WireParseError {}
+
+/// Converts wire command into internal add/cancel command + instrument route key.
+pub enum RoutedCommand {
+    /// Routed add.
+    Add {
+        /// Destination instrument identifier.
+        instrument_id: u32,
+        /// Engine add command payload.
+        add: AddOrderCommand,
+    },
+    /// Routed cancel.
+    CancelById {
+        /// Destination instrument identifier.
+        instrument_id: u32,
+        /// Engine cancel command payload.
+        cancel: CancelByOrderIdCommand,
+    },
+}
+
+/// Parse one protocol line into a frame.
+pub fn parse_frame(line: &str) -> Result<WireFrame, WireParseError> {
+    let line = line.trim();
+    if line.is_empty() {
+        return Err(WireParseError::Empty);
+    }
+
+    if let Some(rest) = line.strip_prefix("BATCH ") {
+        return parse_batch_frame(rest);
+    }
+
+    Ok(WireFrame {
+        commands: vec![parse_single(line)?],
+    })
+}
+
+/// Encode a frame for transport.
+pub fn encode_frame(frame: &WireFrame) -> Result<String, WireParseError> {
+    if frame.commands.is_empty() {
+        return Err(WireParseError::InvalidBatch);
+    }
+    if frame.commands.len() > MAX_BATCH_COMMANDS {
+        return Err(WireParseError::BatchTooLarge);
+    }
+
+    let mut encoded: Vec<String> =
+        frame.commands.iter().map(encode_single).collect();
+    if encoded.len() == 1 {
+        let mut line = encoded.pop().expect("single command exists");
+        line.push('\n');
+        return Ok(line);
+    }
+
+    Ok(format!("BATCH {}\n", encoded.join("|")))
+}
+
+impl WireCommand {
+    /// Convert protocol command into internal routed command.
+    pub fn into_routed(self) -> RoutedCommand {
+        match self {
+            Self::Add {
+                id,
+                participant_id,
+                instrument_id,
+                side,
+                price,
+                quantity,
+            } => RoutedCommand::Add {
+                instrument_id,
+                add: AddOrderCommand {
+                    id,
+                    participant_id,
+                    symbol_id: instrument_id,
+                    side,
+                    order_type: OrderType::Limit,
+                    price: Some(price),
+                    quantity,
+                    time_in_force: TimeInForce::Gtc,
+                    stop_price: None,
+                    max_visible_quantity: None,
+                    slippage: None,
+                    trailing_distance: None,
+                    trailing_step: None,
+                },
+            },
+            Self::Market {
+                id,
+                participant_id,
+                instrument_id,
+                side,
+                quantity,
+            } => RoutedCommand::Add {
+                instrument_id,
+                add: AddOrderCommand {
+                    id,
+                    participant_id,
+                    symbol_id: instrument_id,
+                    side,
+                    order_type: OrderType::Market,
+                    price: None,
+                    quantity,
+                    time_in_force: TimeInForce::Ioc,
+                    stop_price: None,
+                    max_visible_quantity: None,
+                    slippage: None,
+                    trailing_distance: None,
+                    trailing_step: None,
+                },
+            },
+            Self::CancelById {
+                order_id,
+                instrument_id,
+            } => RoutedCommand::CancelById {
+                instrument_id,
+                cancel: CancelByOrderIdCommand { order_id },
+            },
+        }
+    }
+}
+
+fn parse_single(line: &str) -> Result<WireCommand, WireParseError> {
+    let parts: Vec<&str> = line.split_whitespace().collect();
+    if parts.is_empty() {
+        return Err(WireParseError::Empty);
+    }
+
+    match parts[0] {
+        "ADD" if parts.len() == 7 => parse_add(parts.as_slice()),
+        "MARKET" if parts.len() == 6 => parse_market(parts.as_slice()),
+        "CANCELID" if parts.len() == 3 => parse_cancel(parts.as_slice()),
+        _ => Err(WireParseError::Unknown),
+    }
+}
+
+fn parse_batch_frame(rest: &str) -> Result<WireFrame, WireParseError> {
+    let raw_cmds: Vec<&str> = rest.split('|').collect();
+    if raw_cmds.is_empty() || raw_cmds.iter().any(|cmd| cmd.trim().is_empty()) {
+        return Err(WireParseError::InvalidBatch);
+    }
+    if raw_cmds.len() > MAX_BATCH_COMMANDS {
+        return Err(WireParseError::BatchTooLarge);
+    }
+    let mut commands = Vec::with_capacity(raw_cmds.len());
+    for raw in raw_cmds {
+        commands.push(parse_single(raw.trim())?);
+    }
+    Ok(WireFrame { commands })
+}
+
+fn parse_add(parts: &[&str]) -> Result<WireCommand, WireParseError> {
+    let id = parse_u64(parts[1])?;
+    let participant_id = parse_u64(parts[2])?;
+    let instrument_id = parse_u32(parts[3])?;
+    let side = parse_side(parts[4])?;
+    let price = parse_i64(parts[5])?;
+    let quantity = parse_i64(parts[6])?;
+    validate_instrument(instrument_id)?;
+    Ok(WireCommand::Add {
+        id,
+        participant_id,
+        instrument_id,
+        side,
+        price,
+        quantity,
+    })
+}
+
+fn parse_market(parts: &[&str]) -> Result<WireCommand, WireParseError> {
+    let id = parse_u64(parts[1])?;
+    let participant_id = parse_u64(parts[2])?;
+    let instrument_id = parse_u32(parts[3])?;
+    let side = parse_side(parts[4])?;
+    let quantity = parse_i64(parts[5])?;
+    validate_instrument(instrument_id)?;
+    Ok(WireCommand::Market {
+        id,
+        participant_id,
+        instrument_id,
+        side,
+        quantity,
+    })
+}
+
+fn parse_cancel(parts: &[&str]) -> Result<WireCommand, WireParseError> {
+    let order_id = parse_u64(parts[1])?;
+    let instrument_id = parse_u32(parts[2])?;
+    validate_instrument(instrument_id)?;
+    Ok(WireCommand::CancelById {
+        order_id,
+        instrument_id,
+    })
+}
+
+fn encode_single(cmd: &WireCommand) -> String {
+    match cmd {
+        WireCommand::Add {
+            id,
+            participant_id,
+            instrument_id,
+            side,
+            price,
+            quantity,
+        } => format!(
+            "ADD {id} {participant_id} {instrument_id} {} {price} {quantity}",
+            encode_side(*side)
+        ),
+        WireCommand::Market {
+            id,
+            participant_id,
+            instrument_id,
+            side,
+            quantity,
+        } => format!(
+            "MARKET {id} {participant_id} {instrument_id} {} {quantity}",
+            encode_side(*side)
+        ),
+        WireCommand::CancelById {
+            order_id,
+            instrument_id,
+        } => format!("CANCELID {order_id} {instrument_id}"),
+    }
+}
+
+fn validate_instrument(instrument_id: u32) -> Result<(), WireParseError> {
+    if instrument_id == 0 {
+        return Err(WireParseError::InvalidInstrument);
+    }
+    Ok(())
+}
+
+fn parse_side(token: &str) -> Result<Side, WireParseError> {
+    match token {
+        "B" | "BUY" => Ok(Side::Buy),
+        "S" | "SELL" => Ok(Side::Sell),
+        _ => Err(WireParseError::InvalidSide),
+    }
+}
+
+fn encode_side(side: Side) -> &'static str {
+    match side {
+        Side::Buy => "B",
+        Side::Sell => "S",
+    }
+}
+
+fn parse_u64(token: &str) -> Result<u64, WireParseError> {
+    token
+        .parse::<u64>()
+        .map_err(|_| WireParseError::InvalidNumber)
+}
+
+fn parse_u32(token: &str) -> Result<u32, WireParseError> {
+    token
+        .parse::<u32>()
+        .map_err(|_| WireParseError::InvalidNumber)
+}
+
+fn parse_i64(token: &str) -> Result<i64, WireParseError> {
+    token
+        .parse::<i64>()
+        .map_err(|_| WireParseError::InvalidNumber)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        WireCommand, WireFrame, WireParseError, encode_frame, parse_frame,
+    };
+    use crate::types::Side;
+
+    #[test]
+    fn parse_single_add_roundtrip() {
+        let frame = parse_frame("ADD 10 20 2 B 101 5").expect("parse");
+        assert_eq!(
+            frame,
+            WireFrame {
+                commands: vec![WireCommand::Add {
+                    id: 10,
+                    participant_id: 20,
+                    instrument_id: 2,
+                    side: Side::Buy,
+                    price: 101,
+                    quantity: 5
+                }]
+            }
+        );
+        let line = encode_frame(&frame).expect("encode");
+        assert_eq!(line, "ADD 10 20 2 B 101 5\n");
+    }
+
+    #[test]
+    fn parse_batch_frame() {
+        let frame =
+            parse_frame("BATCH ADD 1 2 1 B 100 1|CANCELID 1 1").expect("parse");
+        assert_eq!(frame.commands.len(), 2);
+    }
+
+    #[test]
+    fn reject_zero_instrument() {
+        let err = parse_frame("ADD 1 2 0 B 100 1").expect_err("must fail");
+        assert_eq!(err, WireParseError::InvalidInstrument);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@
 //! `// SAFETY:` plus review.
 
 pub mod book;
+pub mod distributed_wire;
 pub mod engine;
 pub mod error;
 pub mod events;


### PR DESCRIPTION
## Summary
- add `src/distributed_wire.rs` as a shared typed protocol module for `server`/`client` with single-command and `BATCH` frame support
- route gateway traffic deterministically to dedicated instrument workers (`instrument_id -> worker`) and enforce validation on gateway and matcher boundaries
- update harness docs and binary usage to reflect instrument-aware protocol and batch-capable client flow

## Commands run
- make ci
- make quality-gate
- cargo bench --features harness,parallel --bench throughput_sharded_mixed -- --noplot --sample-size 10 --warm-up-time 0.2 --measurement-time 0.5 inmemory

## Measured deltas
- benchmark subset throughput interval improved from prior ~3.81M-5.43M ops/s run to ~6.07M-9.49M ops/s in this run window
- criterion reported improvement with throughput change range `+28.23% .. +120.61%` (short-window sample)

## Risks
- protocol shape is stricter (`CANCELID` now includes instrument), so older ad-hoc payloads are no longer accepted
- this priority establishes architecture boundaries; more workload-level tuning remains for later priorities

## Rollback
- revert commit `412c567`

Closes #32