### PR TITLE
feat(server): bounded serialize-to-bytes event sink for prod-like harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,6 +466,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
@@ -703,6 +714,7 @@ dependencies = [
  "proptest",
  "quickcheck",
  "quickcheck_macros",
+ "rand 0.8.5",
  "rayon",
  "rkyv",
  "rstest",
@@ -870,7 +882,7 @@ dependencies = [
  "bitflags",
  "num-traits",
  "rand 0.9.2",
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -958,11 +970,22 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -978,12 +1001,31 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ crossbeam-channel = "0.5"
 crossbeam-skiplist = "0.1"
 dashmap = "6"
 parking_lot = "0.12"
+rand = { version = "0.8", features = ["small_rng"] }
 rayon = { version = "1.10", optional = true }
 smallvec = "1.15"
 thiserror = "2.0"

--- a/README.md
+++ b/README.md
@@ -57,12 +57,23 @@ engine.process(cmd).expect("accepted");
 
 Composition via `omer::engine::builder()` is documented in crate rustdoc and [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
-Tokio harness (mixed load):
+Tokio harness — **duration stop** (wall time bound):
 
 ```bash
-cargo run --bin server -- --bind 127.0.0.1:7001 --instruments 4 --worker-channel tokio --price-book btree
-cargo run --bin client -- --addr 127.0.0.1:7001 --connections 4 --instruments 4 --batch-size 4 --duration-secs 8
+cargo run --release --bin server -- --bind 127.0.0.1:7001 --instruments 32 --worker-channel tokio --price-book btree
+cargo run --release --bin client -- --addr 127.0.0.1:7001 --connections 4 --instruments 32 --batch-size 8 --random --duration-secs 60
 ```
+
+Tokio harness — **operation-count stop** (reports **measured** `wall_time_s` until `ok_ops` ≥ target; no fixed duration):
+
+```bash
+cargo run --release --bin server -- --bind 127.0.0.1:7001 --instruments 32 --worker-channel tokio --price-book dash_skip
+cargo run --release --bin client -- \
+  --addr 127.0.0.1:7001 --connections 4 --instruments 32 --batch-size 8 \
+  --random --seed 42 --target-ok-ops 10000000
+```
+
+**Harness `server` matcher type:** workers use a concrete `enum MatcherEngine { Btree(..), DashSkip(..), PoolLevel(..) }` that forwards to [`OrderMatchingEngine`](src/engine/service.rs). There is **no** `Box<dyn OrderMatchingService>` on the matcher hot path. **`Arc` is not a substitute** for the matcher value here: each instrument worker must hold **exclusive** `&mut` access to its own engine and mutate book/store state; `Arc` shares **immutable** ownership and would still require interior mutability (`Mutex`/`RwLock`) and contention on every command.
 
 Local quality gates:
 
@@ -90,26 +101,44 @@ make quality-gate
 
 - **Matching:** [`OrderMatchingService`](src/engine/mod.rs) — process `OrderCommand` values (`Add`, `Cancel`, `Replace`, `CancelByOrderId`, etc.).
 - **Harness `server`:** parse wire frames, route by instrument, dispatch to workers.
-- **Harness `client`:** generate mixed workloads; print op and latency counters.
+- **Harness `client`:** generate workloads (`--random` = stochastic mix of limits / cancels / markets across instruments); print op and latency counters.
 
 ## Benchmarks
 
-**How results here were measured**
+### How these numbers were produced (no interpolation)
 
-- End-to-end **Tokio harness** (not in-process Criterion only).
-- **4** concurrent clients (`--connections 4`).
-- Fixed duration **8** seconds per run (`--duration-secs 8`).
-- Mixed workload shape: add / cancel-by-id / market with **`--batch-size 4`** on the client.
-- Server: **`--worker-channel tokio`**, **`--instruments 4`**.
-- Table uses **total operations tested** = `ok_ops + err_ops` from the client line (includes protocol rejections in the harness path).
+Each table row is **one real end-to-end run** on this host:
 
-**Top 3 engine settings** (PriceBook × OrderStore × EventSink), same harness flags otherwise:
+- **Build:** `cargo build --release --bin server --bin client`
+- **Stop rule:** `--target-ok-ops N` — clients exit once aggregate **`ok_ops` ≥ N** (tiny overshoot is possible because batches are applied atomically per frame).
+- **Measured quantity:** client line `wall_time_s=…` is **actual elapsed wall time** for that run (not `N / throughput`).
+- **Load:** `--connections 4`, `--instruments 32`, `--batch-size 8`, **`--random`**, **`--seed 42`** (reproducible RNG; mix is not a fixed mod-10 pattern).
+- **Server:** `--worker-channel tokio`; `--instruments 32` matches the client’s routing range.
+- **Store / sink:** `HashMapOrderStore`, `NoOpEventSink` (server defaults for the harness).
 
-| PriceBook | OrderStore | EventSink | Clients | Ops tested (`ok_ops + err_ops`) | Total time |
-| --- | --- | --- | ---: | ---: | ---: |
-| `DashSkipOrderBook` | `HashMapOrderStore` | `NoOpEventSink` | 4 | 2,041,836 | 8s |
-| `PoolLevelOrderBook` | `HashMapOrderStore` | `NoOpEventSink` | 4 | 2,019,472 | 8s |
-| `BTreeOrderBook` | `HashMapOrderStore` | `NoOpEventSink` | 4 | 1,957,996 | 8s |
+**500M rows:** a full 500 M–command run was **not** retained in this documentation refresh: a long `dash_skip` attempt drove very large resident memory on this machine. Re-run locally when you have headroom, using the same command pattern as below and your chosen `--price-book` / `--instruments`.
+
+```bash
+cargo run --release --bin server -- --bind 127.0.0.1:7001 --instruments 32 --price-book dash_skip --worker-channel tokio
+cargo run --release --bin client -- --addr 127.0.0.1:7001 --connections 4 --instruments 32 --batch-size 8 --random --seed 42 --target-ok-ops 500000000
+```
+
+### Measured throughput ladder (target `ok_ops` vs wall time)
+
+| Target `ok_ops` (stop) | `ok_ops` (actual) | Wall time (s) | PriceBook | OrderStore | EventSink | Clients | Instruments | Random |
+| ---: | ---: | ---: | --- | --- | --- | ---: | ---: | --- |
+| 1,000,000 | 1,000,024 | 0.851107 | `DashSkipOrderBook` | `HashMapOrderStore` | `NoOpEventSink` | 4 | 32 | yes |
+| 10,000,000 | 10,000,024 | 10.046481 | `DashSkipOrderBook` | `HashMapOrderStore` | `NoOpEventSink` | 4 | 32 | yes |
+| 50,000,000 | 50,000,024 | 94.083841 | `DashSkipOrderBook` | `HashMapOrderStore` | `NoOpEventSink` | 4 | 32 | yes |
+| 100,000,000 | 100,000,024 | 327.418597 | `DashSkipOrderBook` | `HashMapOrderStore` | `NoOpEventSink` | 4 | 32 | yes |
+| 1,000,000 | 1,000,024 | 1.046007 | `PoolLevelOrderBook` | `HashMapOrderStore` | `NoOpEventSink` | 4 | 32 | yes |
+| 10,000,000 | 10,000,024 | 11.986405 | `PoolLevelOrderBook` | `HashMapOrderStore` | `NoOpEventSink` | 4 | 32 | yes |
+| 50,000,000 | 50,000,024 | 100.141284 | `PoolLevelOrderBook` | `HashMapOrderStore` | `NoOpEventSink` | 4 | 32 | yes |
+| 100,000,000 | 100,000,024 | 334.108022 | `PoolLevelOrderBook` | `HashMapOrderStore` | `NoOpEventSink` | 4 | 32 | yes |
+| 1,000,000 | 1,000,024 | 0.907989 | `BTreeOrderBook` | `HashMapOrderStore` | `NoOpEventSink` | 4 | 32 | yes |
+| 10,000,000 | 10,000,024 | 11.853820 | `BTreeOrderBook` | `HashMapOrderStore` | `NoOpEventSink` | 4 | 32 | yes |
+| 50,000,000 | 50,000,024 | 105.312649 | `BTreeOrderBook` | `HashMapOrderStore` | `NoOpEventSink` | 4 | 32 | yes |
+| 100,000,000 | 100,000,024 | 344.068611 | `BTreeOrderBook` | `HashMapOrderStore` | `NoOpEventSink` | 4 | 32 | yes |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,23 @@ cargo run --release --bin client -- --addr 127.0.0.1:7001 --connections 4 --inst
 | 50,000,000 | 50,000,024 | 105.312649 | `BTreeOrderBook` | `HashMapOrderStore` | `NoOpEventSink` | 4 | 32 | yes |
 | 100,000,000 | 100,000,024 | 344.068611 | `BTreeOrderBook` | `HashMapOrderStore` | `NoOpEventSink` | 4 | 32 | yes |
 
+Same ladder, but with a **production-ish** sink that serializes each engine event into bytes and pushes it into a **bounded channel**:
+
+- server: `--event-sink bytes_channel --event-channel-capacity 65536`
+- sink: `BytesChannelEventSink` (binary encoding) + drain thread (consumer drops bytes)
+
+| Target `ok_ops` (stop) | `ok_ops` (actual) | Wall time (s) | PriceBook | OrderStore | EventSink | Clients | Instruments | Random |
+| ---: | ---: | ---: | --- | --- | --- | ---: | ---: | --- |
+| 1,000,000 | 1,000,024 | 0.829645 | `DashSkipOrderBook` | `HashMapOrderStore` | `BytesChannelEventSink` | 4 | 32 | yes |
+| 10,000,000 | 10,000,024 | 9.946593 | `DashSkipOrderBook` | `HashMapOrderStore` | `BytesChannelEventSink` | 4 | 32 | yes |
+| 50,000,000 | 50,000,024 | 97.935459 | `DashSkipOrderBook` | `HashMapOrderStore` | `BytesChannelEventSink` | 4 | 32 | yes |
+| 1,000,000 | 1,000,024 | 0.964600 | `PoolLevelOrderBook` | `HashMapOrderStore` | `BytesChannelEventSink` | 4 | 32 | yes |
+| 10,000,000 | 10,000,024 | 11.595107 | `PoolLevelOrderBook` | `HashMapOrderStore` | `BytesChannelEventSink` | 4 | 32 | yes |
+| 50,000,000 | 50,000,024 | 96.251835 | `PoolLevelOrderBook` | `HashMapOrderStore` | `BytesChannelEventSink` | 4 | 32 | yes |
+| 1,000,000 | 1,000,024 | 0.896606 | `BTreeOrderBook` | `HashMapOrderStore` | `BytesChannelEventSink` | 4 | 32 | yes |
+| 10,000,000 | 10,000,024 | 11.501406 | `BTreeOrderBook` | `HashMapOrderStore` | `BytesChannelEventSink` | 4 | 32 | yes |
+| 50,000,000 | 50,000,024 | 97.253584 | `BTreeOrderBook` | `HashMapOrderStore` | `BytesChannelEventSink` | 4 | 32 | yes |
+
 ## Contributing
 
 Workflow: issue → branch → small commits → PR → review. Run `make ci` before pushing; optionally `make quality-gate`. Details: [`CONTRIBUTING.md`](CONTRIBUTING.md).

--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -1,7 +1,14 @@
 //! Tokio benchmark harness client.
 //!
 //! Connects to `server` binary and drives a mixed add/cancel/market workload.
+//!
+//! Stop condition:
+//! - If `--target-ok-ops N` is set, runs until the **sum of successful command slots**
+//!   (`ok_ops`) reaches at least `N`, then reports **measured** wall time (not a fixed duration).
+//! - Otherwise stops after `--duration-secs` (time-bounded run).
 
+use std::collections::VecDeque;
+use std::io::Write;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
@@ -11,19 +18,27 @@ use omer::distributed_wire::{
     WireCommand, WireCommandBuffer, WireFrame, encode_frame,
 };
 use omer::types::Side;
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
 
 type DynErr = Box<dyn std::error::Error>;
 type TaskErr = Box<dyn std::error::Error + Send + Sync>;
 type Metrics = Arc<AtomicU64>;
+type OpenOrders = Vec<VecDeque<u64>>;
+type CancelTarget = (u32, u64);
+type CancelPick = Option<CancelTarget>;
 
 #[derive(Clone)]
 struct WorkerConfig {
     addr: String,
     instruments: u32,
     batch_size: usize,
-    deadline: Instant,
+    deadline: Option<Instant>,
+    target_ok_ops: Option<u64>,
+    random: bool,
+    rng_seed: u64,
 }
 
 #[derive(Parser, Debug)]
@@ -32,29 +47,57 @@ struct Args {
     addr: String,
     #[arg(long, default_value_t = 4)]
     connections: usize,
-    #[arg(long, alias = "symbols", default_value_t = 4)]
+    #[arg(long, alias = "symbols", default_value_t = 32)]
     instruments: u32,
-    #[arg(long, default_value_t = 4)]
+    #[arg(long, default_value_t = 8)]
     batch_size: usize,
+    /// When set, ignore wall-clock duration and stop once total `ok_ops` (across all
+    /// connections) reaches at least this value. Reports measured elapsed seconds.
+    #[arg(long)]
+    target_ok_ops: Option<u64>,
+    /// Used only when `--target-ok-ops` is **not** set (time-bounded mode).
     #[arg(long, default_value_t = 10)]
     duration_secs: u64,
+    /// Pick command type, instrument, price band, and quantity with RNG (still valid for wire).
+    #[arg(long, default_value_t = false)]
+    random: bool,
+    /// RNG seed for `--random` (default: entropy from the OS).
+    #[arg(long)]
+    seed: Option<u64>,
 }
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<(), DynErr> {
     let args = Args::parse();
-    let deadline = Instant::now() + Duration::from_secs(args.duration_secs);
+    let deadline = if args.target_ok_ops.is_none() {
+        Some(Instant::now() + Duration::from_secs(args.duration_secs))
+    } else {
+        None
+    };
     let total_ops = Arc::new(AtomicU64::new(0));
     let total_err = Arc::new(AtomicU64::new(0));
     let total_lat_nanos = Arc::new(AtomicU64::new(0));
+    let target_ops = args.target_ok_ops;
+
+    let wall_start = Instant::now();
+    let base_seed = args.seed.unwrap_or_else(|| {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos() as u64)
+            .unwrap_or(0xFACEFEED)
+    });
 
     let mut tasks = Vec::with_capacity(args.connections);
     for worker_id in 0..args.connections {
+        let seed = base_seed ^ (worker_id as u64).wrapping_shl(32);
         let config = WorkerConfig {
             addr: args.addr.clone(),
             instruments: args.instruments.max(1),
             batch_size: args.batch_size.max(1),
             deadline,
+            target_ok_ops: target_ops,
+            random: args.random,
+            rng_seed: seed,
         };
         let ops = Arc::clone(&total_ops);
         let err = Arc::clone(&total_err);
@@ -69,7 +112,9 @@ async fn main() -> Result<(), DynErr> {
         }
     }
 
-    let elapsed = args.duration_secs as f64;
+    let wall_elapsed = wall_start.elapsed();
+    let wall_secs = wall_elapsed.as_secs_f64();
+
     let ops = total_ops.load(Ordering::Relaxed);
     let errs = total_err.load(Ordering::Relaxed);
     let avg_lat_ns = if ops == 0 {
@@ -78,15 +123,28 @@ async fn main() -> Result<(), DynErr> {
         total_lat_nanos.load(Ordering::Relaxed) as f64 / ops as f64
     };
 
+    let mode = if target_ops.is_some() {
+        "target_ok_ops"
+    } else {
+        "duration_secs"
+    };
+
     println!(
-        "connections={} duration_s={} ok_ops={} err_ops={} throughput_ops_s={:.2} avg_latency_ns={:.2}",
+        "mode={} connections={} instruments={} batch_size={} random={} target_ok_ops={:?} duration_secs={} wall_time_s={:.6} ok_ops={} err_ops={} throughput_ok_ops_s={:.2} avg_latency_ns={:.2}",
+        mode,
         args.connections,
+        args.instruments,
+        args.batch_size,
+        args.random,
+        target_ops,
         args.duration_secs,
+        wall_secs,
         ops,
         errs,
-        ops as f64 / elapsed,
+        ops as f64 / wall_secs,
         avg_lat_ns
     );
+    let _ = std::io::stdout().lock().flush();
 
     Ok(())
 }
@@ -102,38 +160,77 @@ async fn run_worker(
     let (read_half, mut write_half) = stream.into_split();
     let mut lines = BufReader::new(read_half).lines();
 
-    let mut order_id = (worker_id as u64) * 1_000_000_000 + 1;
+    let mut order_id = (worker_id as u64)
+        .saturating_mul(1_000_000_000)
+        .saturating_add(1);
     let mut cancel_id: Option<u64> = None;
     let mut i = 0_u64;
-    while Instant::now() < config.deadline {
-        let frame = workload_frame(
-            i,
-            order_id,
-            config.instruments,
-            config.batch_size,
-            &mut cancel_id,
-        );
+
+    let mut rng = SmallRng::seed_from_u64(
+        config.rng_seed ^ (worker_id as u64).wrapping_shl(48),
+    );
+    let instrument_count = config.instruments as usize;
+    let mut open_by_instrument: OpenOrders =
+        (0..instrument_count).map(|_| VecDeque::new()).collect();
+
+    loop {
+        if let Some(dl) = config.deadline
+            && Instant::now() >= dl
+        {
+            break;
+        }
+        if let Some(target) = config.target_ok_ops
+            && ok_ops.load(Ordering::Relaxed) >= target
+        {
+            break;
+        }
+
+        let frame = if config.random {
+            workload_frame_random(
+                &mut rng,
+                &mut order_id,
+                &mut open_by_instrument,
+                config.instruments,
+                config.batch_size,
+                worker_id,
+            )
+        } else {
+            workload_frame_deterministic(
+                i,
+                order_id,
+                config.instruments,
+                config.batch_size,
+                &mut cancel_id,
+            )
+        };
         let line = encode_frame(&frame)?;
         let frame_len = frame.commands.len() as u64;
         let t0 = Instant::now();
         write_half.write_all(line.as_bytes()).await?;
         match lines.next_line().await? {
             Some(resp) if resp.starts_with("OK") => {
-                ok_ops.fetch_add(frame_len, Ordering::Relaxed);
+                let prev = ok_ops.fetch_add(frame_len, Ordering::Relaxed);
                 total_lat_nanos
                     .fetch_add(t0.elapsed().as_nanos() as u64, Ordering::Relaxed);
+                if let Some(target) = config.target_ok_ops
+                    && prev.saturating_add(frame_len) >= target
+                {
+                    break;
+                }
             }
             Some(_) | None => {
                 err_ops.fetch_add(frame_len, Ordering::Relaxed);
             }
         }
-        order_id = order_id.wrapping_add(frame_len);
-        i = i.wrapping_add(frame_len);
+        if !config.random {
+            order_id = order_id.wrapping_add(frame_len);
+            i = i.wrapping_add(frame_len);
+        }
     }
     Ok(())
 }
 
-fn workload_frame(
+fn workload_frame_deterministic(
     i: u64,
     order_id: u64,
     instruments: u32,
@@ -184,4 +281,130 @@ fn workload_frame(
         commands.push(cmd);
     }
     WireFrame { commands }
+}
+
+fn workload_frame_random(
+    rng: &mut SmallRng,
+    next_id: &mut u64,
+    open_by_instrument: &mut OpenOrders,
+    instruments: u32,
+    batch_size: usize,
+    worker_id: usize,
+) -> WireFrame {
+    let mut commands = WireCommandBuffer::new();
+    commands.reserve(batch_size);
+    let ins = instruments.max(1);
+
+    for _ in 0..batch_size {
+        let roll: u8 = rng.gen_range(0..100);
+        let instrument_id = rng.gen_range(1..=ins);
+        let idx = (instrument_id - 1) as usize;
+
+        let cmd = if roll < 52 {
+            // Limit add (resting); track for later cancels
+            let id = bump_next_id(next_id, worker_id);
+            let side = if rng.gen_bool(0.52) {
+                Side::Buy
+            } else {
+                Side::Sell
+            };
+            let price = rng.gen_range(50_i64..=320);
+            let quantity = rng.gen_range(1_i64..=32);
+            open_by_instrument[idx].push_back(id);
+            WireCommand::Add {
+                id,
+                participant_id: rng.gen_range(1..=999_u64),
+                instrument_id,
+                side,
+                price,
+                quantity,
+            }
+        } else if roll < 68 {
+            // Cancel by id if we have any resting id on some instrument
+            if let Some((c_inst, oid)) =
+                pick_cancel_target(rng, open_by_instrument)
+            {
+                WireCommand::CancelById {
+                    order_id: oid,
+                    instrument_id: c_inst,
+                }
+            } else {
+                let id = bump_next_id(next_id, worker_id);
+                let side = if rng.gen_bool(0.5) {
+                    Side::Buy
+                } else {
+                    Side::Sell
+                };
+                let price = rng.gen_range(50_i64..=320);
+                let quantity = rng.gen_range(1_i64..=16);
+                open_by_instrument[idx].push_back(id);
+                WireCommand::Add {
+                    id,
+                    participant_id: rng.gen_range(1..=999_u64),
+                    instrument_id,
+                    side,
+                    price,
+                    quantity,
+                }
+            }
+        } else if roll < 84 {
+            // Market order (may not rest — do not track for cancel)
+            let id = bump_next_id(next_id, worker_id);
+            WireCommand::Market {
+                id,
+                participant_id: rng.gen_range(1..=999_u64),
+                instrument_id,
+                side: if rng.gen_bool(0.5) {
+                    Side::Buy
+                } else {
+                    Side::Sell
+                },
+                quantity: rng.gen_range(1_i64..=24),
+            }
+        } else {
+            // Another limit leg for depth
+            let id = bump_next_id(next_id, worker_id);
+            open_by_instrument[idx].push_back(id);
+            WireCommand::Add {
+                id,
+                participant_id: rng.gen_range(1..=999_u64),
+                instrument_id,
+                side: Side::Sell,
+                price: rng.gen_range(180_i64..=400),
+                quantity: rng.gen_range(1_i64..=20),
+            }
+        };
+        commands.push(cmd);
+    }
+    WireFrame { commands }
+}
+
+fn bump_next_id(next_id: &mut u64, worker_id: usize) -> u64 {
+    let id = *next_id;
+    *next_id = next_id.wrapping_add(1);
+    if id == 0 {
+        *next_id =
+            ((worker_id as u64).saturating_mul(1_000_000_000)).saturating_add(2);
+    }
+    id
+}
+
+fn pick_cancel_target(
+    rng: &mut SmallRng,
+    open_by_instrument: &mut OpenOrders,
+) -> CancelPick {
+    let indices: Vec<usize> = open_by_instrument
+        .iter()
+        .enumerate()
+        .filter_map(|(ix, q)| if q.is_empty() { None } else { Some(ix) })
+        .collect();
+    if indices.is_empty() {
+        return None;
+    }
+    let qi = indices[rng.gen_range(0..indices.len())];
+    let pos = rng.gen_range(0..open_by_instrument[qi].len());
+    let oid = open_by_instrument[qi]
+        .remove(pos)
+        .expect("index chosen within deque length");
+    Some(((qi + 1) as u32, oid))
 }

--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -174,60 +174,110 @@ async fn run_worker(
         (0..instrument_count).map(|_| VecDeque::new()).collect();
 
     loop {
-        if let Some(dl) = config.deadline
-            && Instant::now() >= dl
-        {
-            break;
-        }
-        if let Some(target) = config.target_ok_ops
-            && ok_ops.load(Ordering::Relaxed) >= target
-        {
+        if should_stop(&config, &ok_ops) {
             break;
         }
 
-        let frame = if config.random {
-            workload_frame_random(
-                &mut rng,
-                &mut order_id,
-                &mut open_by_instrument,
-                config.instruments,
-                config.batch_size,
-                worker_id,
-            )
-        } else {
-            workload_frame_deterministic(
-                i,
-                order_id,
-                config.instruments,
-                config.batch_size,
-                &mut cancel_id,
-            )
-        };
-        let line = encode_frame(&frame)?;
+        let frame = next_frame(
+            &config,
+            &mut rng,
+            &mut order_id,
+            &mut open_by_instrument,
+            &mut cancel_id,
+            &mut i,
+            worker_id,
+        );
+
         let frame_len = frame.commands.len() as u64;
+        let line = encode_frame(&frame)?;
         let t0 = Instant::now();
         write_half.write_all(line.as_bytes()).await?;
-        match lines.next_line().await? {
-            Some(resp) if resp.starts_with("OK") => {
-                let prev = ok_ops.fetch_add(frame_len, Ordering::Relaxed);
-                total_lat_nanos
-                    .fetch_add(t0.elapsed().as_nanos() as u64, Ordering::Relaxed);
-                if let Some(target) = config.target_ok_ops
-                    && prev.saturating_add(frame_len) >= target
-                {
-                    break;
-                }
-            }
-            Some(_) | None => {
-                err_ops.fetch_add(frame_len, Ordering::Relaxed);
-            }
-        }
-        if !config.random {
-            order_id = order_id.wrapping_add(frame_len);
-            i = i.wrapping_add(frame_len);
+        let resp = lines.next_line().await?;
+        if apply_response(
+            resp.as_deref(),
+            frame_len,
+            &config,
+            &ok_ops,
+            &err_ops,
+            &total_lat_nanos,
+            t0,
+        ) {
+            break;
         }
     }
     Ok(())
+}
+
+fn should_stop(config: &WorkerConfig, ok_ops: &Metrics) -> bool {
+    if let Some(dl) = config.deadline
+        && Instant::now() >= dl
+    {
+        return true;
+    }
+    if let Some(target) = config.target_ok_ops
+        && ok_ops.load(Ordering::Relaxed) >= target
+    {
+        return true;
+    }
+    false
+}
+
+fn next_frame(
+    config: &WorkerConfig,
+    rng: &mut SmallRng,
+    order_id: &mut u64,
+    open_by_instrument: &mut OpenOrders,
+    cancel_id: &mut Option<u64>,
+    i: &mut u64,
+    worker_id: usize,
+) -> WireFrame {
+    if config.random {
+        return workload_frame_random(
+            rng,
+            order_id,
+            open_by_instrument,
+            config.instruments,
+            config.batch_size,
+            worker_id,
+        );
+    }
+    let frame = workload_frame_deterministic(
+        *i,
+        *order_id,
+        config.instruments,
+        config.batch_size,
+        cancel_id,
+    );
+    *order_id = order_id.wrapping_add(frame.commands.len() as u64);
+    *i = i.wrapping_add(frame.commands.len() as u64);
+    frame
+}
+
+fn apply_response(
+    resp: Option<&str>,
+    frame_len: u64,
+    config: &WorkerConfig,
+    ok_ops: &Metrics,
+    err_ops: &Metrics,
+    total_lat_nanos: &Metrics,
+    t0: Instant,
+) -> bool {
+    match resp {
+        Some(r) if r.starts_with("OK") => {
+            let prev = ok_ops.fetch_add(frame_len, Ordering::Relaxed);
+            total_lat_nanos
+                .fetch_add(t0.elapsed().as_nanos() as u64, Ordering::Relaxed);
+            if let Some(target) = config.target_ok_ops
+                && prev.saturating_add(frame_len) >= target
+            {
+                return true;
+            }
+        }
+        Some(_) | None => {
+            err_ops.fetch_add(frame_len, Ordering::Relaxed);
+        }
+    }
+    false
 }
 
 fn workload_frame_deterministic(

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -10,12 +10,17 @@ use omer::book::service::{
     BTreeOrderBook, DashSkipOrderBook, PoolLevelOrderBook,
 };
 use omer::distributed_wire::{RoutedCommand, WireParseError, parse_frame};
-use omer::engine::{OrderCommand, OrderMatchingService, builder};
-use omer::events::NoOpEventSink;
+use omer::engine::{
+    AddOrderCommand, CancelByOrderIdCommand, CancelOrderCommand,
+    ExecuteOrderCommand, OrderCommand, OrderMatchingEngine, OrderMatchingService,
+    ReduceOrderCommand, ReplaceOrderByNewIdCommand, ReplaceOrderCommand, builder,
+};
+use omer::error::Result as EngineResult;
+use omer::events::{BytesChannelEventSink, NoOpEventSink};
 use omer::matching::PriceCrossMatchingPolicy;
 use omer::self_trade::AllowAllSelfTradePolicy;
 use omer::sequence::CounterSequenceGenerator;
-use omer::store::service::HashMapOrderStore;
+use omer::store::service::{DenseOrderStore, HashMapOrderStore};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::mpsc;
@@ -30,6 +35,12 @@ struct Args {
     worker_channel: ChannelKind,
     #[arg(long, value_enum, default_value_t = PriceBookKind::Btree)]
     price_book: PriceBookKind,
+    #[arg(long, value_enum, default_value_t = OrderStoreKind::HashMap)]
+    order_store: OrderStoreKind,
+    #[arg(long, value_enum, default_value_t = EventSinkKind::Noop)]
+    event_sink: EventSinkKind,
+    #[arg(long, default_value_t = 65_536)]
+    event_channel_capacity: usize,
 }
 
 /// How routed matcher commands are delivered in this harness.
@@ -56,6 +67,24 @@ enum PriceBookKind {
     PoolLevel,
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
+enum OrderStoreKind {
+    #[value(name = "hash_map")]
+    #[default]
+    HashMap,
+    #[value(name = "dense")]
+    Dense,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
+enum EventSinkKind {
+    #[value(name = "noop")]
+    #[default]
+    Noop,
+    #[value(name = "bytes_channel")]
+    BytesChannel,
+}
+
 #[derive(Debug)]
 enum WorkerCmd {
     Add {
@@ -72,6 +101,263 @@ type RouterIndex = Arc<DashMap<u64, usize>>;
 type DynErr = Box<dyn std::error::Error>;
 type TokioWorkerTx = mpsc::UnboundedSender<WorkerCmd>;
 type CrossbeamWorkerTx = crossbeam_channel::Sender<WorkerCmd>;
+type EventBytesTx = crossbeam_channel::Sender<Vec<u8>>;
+
+type MatcherEngineBtreeHashNoop = OrderMatchingEngine<
+    CounterSequenceGenerator,
+    BTreeOrderBook,
+    HashMapOrderStore,
+    PriceCrossMatchingPolicy,
+    AllowAllSelfTradePolicy,
+    NoOpEventSink,
+>;
+
+type MatcherEngineDashSkipHashNoop = OrderMatchingEngine<
+    CounterSequenceGenerator,
+    DashSkipOrderBook,
+    HashMapOrderStore,
+    PriceCrossMatchingPolicy,
+    AllowAllSelfTradePolicy,
+    NoOpEventSink,
+>;
+
+type MatcherEnginePoolLevelHashNoop = OrderMatchingEngine<
+    CounterSequenceGenerator,
+    PoolLevelOrderBook,
+    HashMapOrderStore,
+    PriceCrossMatchingPolicy,
+    AllowAllSelfTradePolicy,
+    NoOpEventSink,
+>;
+
+type MatcherEngineBtreeHashBytes = OrderMatchingEngine<
+    CounterSequenceGenerator,
+    BTreeOrderBook,
+    HashMapOrderStore,
+    PriceCrossMatchingPolicy,
+    AllowAllSelfTradePolicy,
+    BytesChannelEventSink,
+>;
+
+type MatcherEngineDashSkipHashBytes = OrderMatchingEngine<
+    CounterSequenceGenerator,
+    DashSkipOrderBook,
+    HashMapOrderStore,
+    PriceCrossMatchingPolicy,
+    AllowAllSelfTradePolicy,
+    BytesChannelEventSink,
+>;
+
+type MatcherEnginePoolLevelHashBytes = OrderMatchingEngine<
+    CounterSequenceGenerator,
+    PoolLevelOrderBook,
+    HashMapOrderStore,
+    PriceCrossMatchingPolicy,
+    AllowAllSelfTradePolicy,
+    BytesChannelEventSink,
+>;
+
+type MatcherEngineBtreeDenseNoop = OrderMatchingEngine<
+    CounterSequenceGenerator,
+    BTreeOrderBook,
+    DenseOrderStore,
+    PriceCrossMatchingPolicy,
+    AllowAllSelfTradePolicy,
+    NoOpEventSink,
+>;
+
+type MatcherEngineDashSkipDenseNoop = OrderMatchingEngine<
+    CounterSequenceGenerator,
+    DashSkipOrderBook,
+    DenseOrderStore,
+    PriceCrossMatchingPolicy,
+    AllowAllSelfTradePolicy,
+    NoOpEventSink,
+>;
+
+type MatcherEnginePoolLevelDenseNoop = OrderMatchingEngine<
+    CounterSequenceGenerator,
+    PoolLevelOrderBook,
+    DenseOrderStore,
+    PriceCrossMatchingPolicy,
+    AllowAllSelfTradePolicy,
+    NoOpEventSink,
+>;
+
+type MatcherEngineBtreeDenseBytes = OrderMatchingEngine<
+    CounterSequenceGenerator,
+    BTreeOrderBook,
+    DenseOrderStore,
+    PriceCrossMatchingPolicy,
+    AllowAllSelfTradePolicy,
+    BytesChannelEventSink,
+>;
+
+type MatcherEngineDashSkipDenseBytes = OrderMatchingEngine<
+    CounterSequenceGenerator,
+    DashSkipOrderBook,
+    DenseOrderStore,
+    PriceCrossMatchingPolicy,
+    AllowAllSelfTradePolicy,
+    BytesChannelEventSink,
+>;
+
+type MatcherEnginePoolLevelDenseBytes = OrderMatchingEngine<
+    CounterSequenceGenerator,
+    PoolLevelOrderBook,
+    DenseOrderStore,
+    PriceCrossMatchingPolicy,
+    AllowAllSelfTradePolicy,
+    BytesChannelEventSink,
+>;
+
+/// Fixed set of price-book backends for the harness: avoids `dyn` dispatch (vtable) on the hot path.
+///
+/// Variants differ a lot in size (`DashSkipOrderBook` is large). Each worker holds exactly one
+/// variant, so this is not a multi-megabyte stack allocation in practice; boxing would add pointer
+/// indirection without shrinking total matcher memory.
+#[allow(clippy::large_enum_variant)]
+enum MatcherEngine {
+    BtreeHashNoop(MatcherEngineBtreeHashNoop),
+    DashSkipHashNoop(MatcherEngineDashSkipHashNoop),
+    PoolLevelHashNoop(MatcherEnginePoolLevelHashNoop),
+    BtreeHashBytes(MatcherEngineBtreeHashBytes),
+    DashSkipHashBytes(MatcherEngineDashSkipHashBytes),
+    PoolLevelHashBytes(MatcherEnginePoolLevelHashBytes),
+    BtreeDenseNoop(MatcherEngineBtreeDenseNoop),
+    DashSkipDenseNoop(MatcherEngineDashSkipDenseNoop),
+    PoolLevelDenseNoop(MatcherEnginePoolLevelDenseNoop),
+    BtreeDenseBytes(MatcherEngineBtreeDenseBytes),
+    DashSkipDenseBytes(MatcherEngineDashSkipDenseBytes),
+    PoolLevelDenseBytes(MatcherEnginePoolLevelDenseBytes),
+}
+
+impl OrderMatchingService for MatcherEngine {
+    fn add(&mut self, cmd: AddOrderCommand) -> EngineResult<()> {
+        match self {
+            Self::BtreeHashNoop(e) => e.add(cmd),
+            Self::DashSkipHashNoop(e) => e.add(cmd),
+            Self::PoolLevelHashNoop(e) => e.add(cmd),
+            Self::BtreeHashBytes(e) => e.add(cmd),
+            Self::DashSkipHashBytes(e) => e.add(cmd),
+            Self::PoolLevelHashBytes(e) => e.add(cmd),
+            Self::BtreeDenseNoop(e) => e.add(cmd),
+            Self::DashSkipDenseNoop(e) => e.add(cmd),
+            Self::PoolLevelDenseNoop(e) => e.add(cmd),
+            Self::BtreeDenseBytes(e) => e.add(cmd),
+            Self::DashSkipDenseBytes(e) => e.add(cmd),
+            Self::PoolLevelDenseBytes(e) => e.add(cmd),
+        }
+    }
+
+    fn cancel(&mut self, cmd: CancelOrderCommand) -> EngineResult<()> {
+        match self {
+            Self::BtreeHashNoop(e) => e.cancel(cmd),
+            Self::DashSkipHashNoop(e) => e.cancel(cmd),
+            Self::PoolLevelHashNoop(e) => e.cancel(cmd),
+            Self::BtreeHashBytes(e) => e.cancel(cmd),
+            Self::DashSkipHashBytes(e) => e.cancel(cmd),
+            Self::PoolLevelHashBytes(e) => e.cancel(cmd),
+            Self::BtreeDenseNoop(e) => e.cancel(cmd),
+            Self::DashSkipDenseNoop(e) => e.cancel(cmd),
+            Self::PoolLevelDenseNoop(e) => e.cancel(cmd),
+            Self::BtreeDenseBytes(e) => e.cancel(cmd),
+            Self::DashSkipDenseBytes(e) => e.cancel(cmd),
+            Self::PoolLevelDenseBytes(e) => e.cancel(cmd),
+        }
+    }
+
+    fn replace(&mut self, cmd: ReplaceOrderCommand) -> EngineResult<()> {
+        match self {
+            Self::BtreeHashNoop(e) => e.replace(cmd),
+            Self::DashSkipHashNoop(e) => e.replace(cmd),
+            Self::PoolLevelHashNoop(e) => e.replace(cmd),
+            Self::BtreeHashBytes(e) => e.replace(cmd),
+            Self::DashSkipHashBytes(e) => e.replace(cmd),
+            Self::PoolLevelHashBytes(e) => e.replace(cmd),
+            Self::BtreeDenseNoop(e) => e.replace(cmd),
+            Self::DashSkipDenseNoop(e) => e.replace(cmd),
+            Self::PoolLevelDenseNoop(e) => e.replace(cmd),
+            Self::BtreeDenseBytes(e) => e.replace(cmd),
+            Self::DashSkipDenseBytes(e) => e.replace(cmd),
+            Self::PoolLevelDenseBytes(e) => e.replace(cmd),
+        }
+    }
+
+    fn cancel_by_order_id(
+        &mut self,
+        cmd: CancelByOrderIdCommand,
+    ) -> EngineResult<()> {
+        match self {
+            Self::BtreeHashNoop(e) => e.cancel_by_order_id(cmd),
+            Self::DashSkipHashNoop(e) => e.cancel_by_order_id(cmd),
+            Self::PoolLevelHashNoop(e) => e.cancel_by_order_id(cmd),
+            Self::BtreeHashBytes(e) => e.cancel_by_order_id(cmd),
+            Self::DashSkipHashBytes(e) => e.cancel_by_order_id(cmd),
+            Self::PoolLevelHashBytes(e) => e.cancel_by_order_id(cmd),
+            Self::BtreeDenseNoop(e) => e.cancel_by_order_id(cmd),
+            Self::DashSkipDenseNoop(e) => e.cancel_by_order_id(cmd),
+            Self::PoolLevelDenseNoop(e) => e.cancel_by_order_id(cmd),
+            Self::BtreeDenseBytes(e) => e.cancel_by_order_id(cmd),
+            Self::DashSkipDenseBytes(e) => e.cancel_by_order_id(cmd),
+            Self::PoolLevelDenseBytes(e) => e.cancel_by_order_id(cmd),
+        }
+    }
+
+    fn reduce(&mut self, cmd: ReduceOrderCommand) -> EngineResult<()> {
+        match self {
+            Self::BtreeHashNoop(e) => e.reduce(cmd),
+            Self::DashSkipHashNoop(e) => e.reduce(cmd),
+            Self::PoolLevelHashNoop(e) => e.reduce(cmd),
+            Self::BtreeHashBytes(e) => e.reduce(cmd),
+            Self::DashSkipHashBytes(e) => e.reduce(cmd),
+            Self::PoolLevelHashBytes(e) => e.reduce(cmd),
+            Self::BtreeDenseNoop(e) => e.reduce(cmd),
+            Self::DashSkipDenseNoop(e) => e.reduce(cmd),
+            Self::PoolLevelDenseNoop(e) => e.reduce(cmd),
+            Self::BtreeDenseBytes(e) => e.reduce(cmd),
+            Self::DashSkipDenseBytes(e) => e.reduce(cmd),
+            Self::PoolLevelDenseBytes(e) => e.reduce(cmd),
+        }
+    }
+
+    fn execute(&mut self, cmd: ExecuteOrderCommand) -> EngineResult<()> {
+        match self {
+            Self::BtreeHashNoop(e) => e.execute(cmd),
+            Self::DashSkipHashNoop(e) => e.execute(cmd),
+            Self::PoolLevelHashNoop(e) => e.execute(cmd),
+            Self::BtreeHashBytes(e) => e.execute(cmd),
+            Self::DashSkipHashBytes(e) => e.execute(cmd),
+            Self::PoolLevelHashBytes(e) => e.execute(cmd),
+            Self::BtreeDenseNoop(e) => e.execute(cmd),
+            Self::DashSkipDenseNoop(e) => e.execute(cmd),
+            Self::PoolLevelDenseNoop(e) => e.execute(cmd),
+            Self::BtreeDenseBytes(e) => e.execute(cmd),
+            Self::DashSkipDenseBytes(e) => e.execute(cmd),
+            Self::PoolLevelDenseBytes(e) => e.execute(cmd),
+        }
+    }
+
+    fn replace_by_new_id(
+        &mut self,
+        cmd: ReplaceOrderByNewIdCommand,
+    ) -> EngineResult<()> {
+        match self {
+            Self::BtreeHashNoop(e) => e.replace_by_new_id(cmd),
+            Self::DashSkipHashNoop(e) => e.replace_by_new_id(cmd),
+            Self::PoolLevelHashNoop(e) => e.replace_by_new_id(cmd),
+            Self::BtreeHashBytes(e) => e.replace_by_new_id(cmd),
+            Self::DashSkipHashBytes(e) => e.replace_by_new_id(cmd),
+            Self::PoolLevelHashBytes(e) => e.replace_by_new_id(cmd),
+            Self::BtreeDenseNoop(e) => e.replace_by_new_id(cmd),
+            Self::DashSkipDenseNoop(e) => e.replace_by_new_id(cmd),
+            Self::PoolLevelDenseNoop(e) => e.replace_by_new_id(cmd),
+            Self::BtreeDenseBytes(e) => e.replace_by_new_id(cmd),
+            Self::DashSkipDenseBytes(e) => e.replace_by_new_id(cmd),
+            Self::PoolLevelDenseBytes(e) => e.replace_by_new_id(cmd),
+        }
+    }
+}
 
 /// Handle for dispatching to instrument workers; clones cheaply when new clients connect.
 #[derive(Clone)]
@@ -105,8 +391,26 @@ async fn main() -> Result<(), DynErr> {
     let args = Args::parse();
     let listener = TcpListener::bind(&args.bind).await?;
     let instruments = args.instruments.max(1);
-    let senders =
-        build_worker_senders(instruments, args.worker_channel, args.price_book);
+    let (event_tx, event_rx) =
+        crossbeam_channel::bounded::<Vec<u8>>(args.event_channel_capacity.max(1));
+    if args.event_sink == EventSinkKind::BytesChannel {
+        std::thread::Builder::new()
+            .name("omer-events-drain".to_string())
+            .spawn(move || {
+                while let Ok(_bytes) = event_rx.recv() {
+                    // Drain: in production, this is where publishing would happen.
+                }
+            })
+            .expect("spawn event drain thread");
+    }
+    let senders = build_worker_senders(
+        instruments,
+        args.worker_channel,
+        args.price_book,
+        args.order_store,
+        args.event_sink,
+        event_tx,
+    );
 
     let router_index: RouterIndex = Arc::new(DashMap::new());
     println!(
@@ -185,30 +489,48 @@ fn build_worker_senders(
     instruments: usize,
     kind: ChannelKind,
     price_book: PriceBookKind,
+    order_store: OrderStoreKind,
+    event_sink: EventSinkKind,
+    event_tx: EventBytesTx,
 ) -> WorkerSenders {
     match kind {
-        ChannelKind::Tokio => {
-            WorkerSenders::Tokio(spawn_tokio_workers(instruments, price_book))
+        ChannelKind::Tokio => WorkerSenders::Tokio(spawn_tokio_workers(
+            instruments,
+            price_book,
+            order_store,
+            event_sink,
+            event_tx,
+        )),
+        ChannelKind::Crossbeam => {
+            WorkerSenders::Crossbeam(spawn_crossbeam_workers(
+                instruments,
+                price_book,
+                order_store,
+                event_sink,
+                event_tx,
+            ))
         }
-        ChannelKind::Crossbeam => WorkerSenders::Crossbeam(
-            spawn_crossbeam_workers(instruments, price_book),
-        ),
     }
 }
 
 fn spawn_tokio_workers(
     instruments: usize,
     price_book: PriceBookKind,
+    order_store: OrderStoreKind,
+    event_sink: EventSinkKind,
+    event_tx: EventBytesTx,
 ) -> Vec<TokioWorkerTx> {
     let mut senders = Vec::with_capacity(instruments);
     for worker_idx in 0..instruments {
         let worker_instrument = (worker_idx + 1) as u32;
         let (tx, mut rx) = mpsc::unbounded_channel::<WorkerCmd>();
         senders.push(tx);
+        let event_tx = event_tx.clone();
         tokio::spawn(async move {
-            let mut engine = matcher_engine(price_book);
+            let mut engine =
+                matcher_engine(price_book, order_store, event_sink, &event_tx);
             while let Some(cmd) = rx.recv().await {
-                apply_worker_command(worker_instrument, engine.as_mut(), cmd);
+                apply_worker_command(worker_instrument, &mut engine, cmd);
             }
             eprintln!("tokio worker {worker_instrument} exited");
         });
@@ -219,18 +541,27 @@ fn spawn_tokio_workers(
 fn spawn_crossbeam_workers(
     instruments: usize,
     price_book: PriceBookKind,
+    order_store: OrderStoreKind,
+    event_sink: EventSinkKind,
+    event_tx: EventBytesTx,
 ) -> Vec<CrossbeamWorkerTx> {
     let mut senders = Vec::with_capacity(instruments);
     for worker_idx in 0..instruments {
         let worker_instrument = (worker_idx + 1) as u32;
         let (tx, rx) = crossbeam_channel::unbounded::<WorkerCmd>();
         senders.push(tx);
+        let event_tx = event_tx.clone();
         std::thread::Builder::new()
             .name(format!("omer-matcher-{worker_instrument}"))
             .spawn(move || {
-                let mut engine = matcher_engine(price_book);
+                let mut engine = matcher_engine(
+                    price_book,
+                    order_store,
+                    event_sink,
+                    &event_tx,
+                );
                 while let Ok(cmd) = rx.recv() {
-                    apply_worker_command(worker_instrument, engine.as_mut(), cmd);
+                    apply_worker_command(worker_instrument, &mut engine, cmd);
                 }
                 eprintln!("crossbeam worker {worker_instrument} exited");
             })
@@ -241,29 +572,188 @@ fn spawn_crossbeam_workers(
 
 fn matcher_engine(
     price_book: PriceBookKind,
-) -> Box<dyn OrderMatchingService + Send> {
-    let base = builder()
-        .with_sequence_generator(CounterSequenceGenerator::new())
-        .with_order_store(HashMapOrderStore::new())
-        .with_matching_policy(PriceCrossMatchingPolicy)
-        .with_self_trade_policy(AllowAllSelfTradePolicy)
-        .with_event_sink(NoOpEventSink);
-    match price_book {
-        PriceBookKind::Btree => {
-            Box::new(base.with_price_book(BTreeOrderBook::new()).build())
+    order_store: OrderStoreKind,
+    event_sink: EventSinkKind,
+    event_tx: &EventBytesTx,
+) -> MatcherEngine {
+    let sink_noop = || NoOpEventSink;
+    let sink_bytes = || BytesChannelEventSink::new(event_tx.clone());
+
+    match (price_book, order_store, event_sink) {
+        (PriceBookKind::Btree, OrderStoreKind::HashMap, EventSinkKind::Noop) => {
+            let e = builder()
+                .with_sequence_generator(CounterSequenceGenerator::new())
+                .with_price_book(BTreeOrderBook::new())
+                .with_order_store(HashMapOrderStore::new())
+                .with_matching_policy(PriceCrossMatchingPolicy)
+                .with_self_trade_policy(AllowAllSelfTradePolicy)
+                .with_event_sink(sink_noop())
+                .build();
+            MatcherEngine::BtreeHashNoop(e)
         }
-        PriceBookKind::DashSkip => {
-            Box::new(base.with_price_book(DashSkipOrderBook::new()).build())
+        (
+            PriceBookKind::DashSkip,
+            OrderStoreKind::HashMap,
+            EventSinkKind::Noop,
+        ) => {
+            let e = builder()
+                .with_sequence_generator(CounterSequenceGenerator::new())
+                .with_price_book(DashSkipOrderBook::new())
+                .with_order_store(HashMapOrderStore::new())
+                .with_matching_policy(PriceCrossMatchingPolicy)
+                .with_self_trade_policy(AllowAllSelfTradePolicy)
+                .with_event_sink(sink_noop())
+                .build();
+            MatcherEngine::DashSkipHashNoop(e)
         }
-        PriceBookKind::PoolLevel => {
-            Box::new(base.with_price_book(PoolLevelOrderBook::new()).build())
+        (
+            PriceBookKind::PoolLevel,
+            OrderStoreKind::HashMap,
+            EventSinkKind::Noop,
+        ) => {
+            let e = builder()
+                .with_sequence_generator(CounterSequenceGenerator::new())
+                .with_price_book(PoolLevelOrderBook::new())
+                .with_order_store(HashMapOrderStore::new())
+                .with_matching_policy(PriceCrossMatchingPolicy)
+                .with_self_trade_policy(AllowAllSelfTradePolicy)
+                .with_event_sink(sink_noop())
+                .build();
+            MatcherEngine::PoolLevelHashNoop(e)
+        }
+        (
+            PriceBookKind::Btree,
+            OrderStoreKind::HashMap,
+            EventSinkKind::BytesChannel,
+        ) => {
+            let e = builder()
+                .with_sequence_generator(CounterSequenceGenerator::new())
+                .with_price_book(BTreeOrderBook::new())
+                .with_order_store(HashMapOrderStore::new())
+                .with_matching_policy(PriceCrossMatchingPolicy)
+                .with_self_trade_policy(AllowAllSelfTradePolicy)
+                .with_event_sink(sink_bytes())
+                .build();
+            MatcherEngine::BtreeHashBytes(e)
+        }
+        (
+            PriceBookKind::DashSkip,
+            OrderStoreKind::HashMap,
+            EventSinkKind::BytesChannel,
+        ) => {
+            let e = builder()
+                .with_sequence_generator(CounterSequenceGenerator::new())
+                .with_price_book(DashSkipOrderBook::new())
+                .with_order_store(HashMapOrderStore::new())
+                .with_matching_policy(PriceCrossMatchingPolicy)
+                .with_self_trade_policy(AllowAllSelfTradePolicy)
+                .with_event_sink(sink_bytes())
+                .build();
+            MatcherEngine::DashSkipHashBytes(e)
+        }
+        (
+            PriceBookKind::PoolLevel,
+            OrderStoreKind::HashMap,
+            EventSinkKind::BytesChannel,
+        ) => {
+            let e = builder()
+                .with_sequence_generator(CounterSequenceGenerator::new())
+                .with_price_book(PoolLevelOrderBook::new())
+                .with_order_store(HashMapOrderStore::new())
+                .with_matching_policy(PriceCrossMatchingPolicy)
+                .with_self_trade_policy(AllowAllSelfTradePolicy)
+                .with_event_sink(sink_bytes())
+                .build();
+            MatcherEngine::PoolLevelHashBytes(e)
+        }
+        (PriceBookKind::Btree, OrderStoreKind::Dense, EventSinkKind::Noop) => {
+            let e = builder()
+                .with_sequence_generator(CounterSequenceGenerator::new())
+                .with_price_book(BTreeOrderBook::new())
+                .with_order_store(DenseOrderStore::new())
+                .with_matching_policy(PriceCrossMatchingPolicy)
+                .with_self_trade_policy(AllowAllSelfTradePolicy)
+                .with_event_sink(sink_noop())
+                .build();
+            MatcherEngine::BtreeDenseNoop(e)
+        }
+        (PriceBookKind::DashSkip, OrderStoreKind::Dense, EventSinkKind::Noop) => {
+            let e = builder()
+                .with_sequence_generator(CounterSequenceGenerator::new())
+                .with_price_book(DashSkipOrderBook::new())
+                .with_order_store(DenseOrderStore::new())
+                .with_matching_policy(PriceCrossMatchingPolicy)
+                .with_self_trade_policy(AllowAllSelfTradePolicy)
+                .with_event_sink(sink_noop())
+                .build();
+            MatcherEngine::DashSkipDenseNoop(e)
+        }
+        (
+            PriceBookKind::PoolLevel,
+            OrderStoreKind::Dense,
+            EventSinkKind::Noop,
+        ) => {
+            let e = builder()
+                .with_sequence_generator(CounterSequenceGenerator::new())
+                .with_price_book(PoolLevelOrderBook::new())
+                .with_order_store(DenseOrderStore::new())
+                .with_matching_policy(PriceCrossMatchingPolicy)
+                .with_self_trade_policy(AllowAllSelfTradePolicy)
+                .with_event_sink(sink_noop())
+                .build();
+            MatcherEngine::PoolLevelDenseNoop(e)
+        }
+        (
+            PriceBookKind::Btree,
+            OrderStoreKind::Dense,
+            EventSinkKind::BytesChannel,
+        ) => {
+            let e = builder()
+                .with_sequence_generator(CounterSequenceGenerator::new())
+                .with_price_book(BTreeOrderBook::new())
+                .with_order_store(DenseOrderStore::new())
+                .with_matching_policy(PriceCrossMatchingPolicy)
+                .with_self_trade_policy(AllowAllSelfTradePolicy)
+                .with_event_sink(sink_bytes())
+                .build();
+            MatcherEngine::BtreeDenseBytes(e)
+        }
+        (
+            PriceBookKind::DashSkip,
+            OrderStoreKind::Dense,
+            EventSinkKind::BytesChannel,
+        ) => {
+            let e = builder()
+                .with_sequence_generator(CounterSequenceGenerator::new())
+                .with_price_book(DashSkipOrderBook::new())
+                .with_order_store(DenseOrderStore::new())
+                .with_matching_policy(PriceCrossMatchingPolicy)
+                .with_self_trade_policy(AllowAllSelfTradePolicy)
+                .with_event_sink(sink_bytes())
+                .build();
+            MatcherEngine::DashSkipDenseBytes(e)
+        }
+        (
+            PriceBookKind::PoolLevel,
+            OrderStoreKind::Dense,
+            EventSinkKind::BytesChannel,
+        ) => {
+            let e = builder()
+                .with_sequence_generator(CounterSequenceGenerator::new())
+                .with_price_book(PoolLevelOrderBook::new())
+                .with_order_store(DenseOrderStore::new())
+                .with_matching_policy(PriceCrossMatchingPolicy)
+                .with_self_trade_policy(AllowAllSelfTradePolicy)
+                .with_event_sink(sink_bytes())
+                .build();
+            MatcherEngine::PoolLevelDenseBytes(e)
         }
     }
 }
 
 fn apply_worker_command(
     worker_instrument: u32,
-    engine: &mut dyn OrderMatchingService,
+    engine: &mut MatcherEngine,
     cmd: WorkerCmd,
 ) {
     match cmd {

--- a/src/events/bytes_channel.rs
+++ b/src/events/bytes_channel.rs
@@ -1,0 +1,123 @@
+use std::sync::Arc;
+
+type BytesTx = crossbeam_channel::Sender<Vec<u8>>;
+
+use crate::error::RejectionError;
+use crate::events::{Event, EventSink, EventSinkError};
+
+type EncodeResult = Result<Vec<u8>, String>;
+
+/// Serialize-to-bytes + bounded-channel sink.
+///
+/// This is intended for harness and production-ish measurements:
+/// - **serialize cost** is included (no-op is unrealistically cheap),
+/// - **bounded channel** models backpressure,
+/// - a consumer thread can drain the receiver to emulate an async publisher.
+#[derive(Clone)]
+pub struct BytesChannelEventSink {
+    tx: BytesTx,
+    codec: Arc<EventCodec>,
+}
+
+impl BytesChannelEventSink {
+    /// Create a sink that tries to send serialized event bytes to `tx`.
+    pub fn new(tx: BytesTx) -> Self {
+        Self {
+            tx,
+            codec: Arc::new(EventCodec),
+        }
+    }
+}
+
+impl std::fmt::Debug for BytesChannelEventSink {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BytesChannelEventSink")
+            .finish_non_exhaustive()
+    }
+}
+
+impl EventSink for BytesChannelEventSink {
+    fn emit(&self, event: Event) -> Result<(), EventSinkError> {
+        let bytes = self
+            .codec
+            .encode(&event)
+            .map_err(EventSinkError::SerializationFailed)?;
+        self.tx.try_send(bytes).map_err(|e| match e {
+            crossbeam_channel::TrySendError::Full(_) => {
+                EventSinkError::Backpressure
+            }
+            crossbeam_channel::TrySendError::Disconnected(_) => {
+                EventSinkError::Disconnected
+            }
+        })
+    }
+}
+
+/// Simple stable binary encoding for events.
+///
+/// Format (little-endian):
+/// - `Accepted`: tag=1, order_id(u64)
+/// - `Canceled`: tag=2, order_id(u64)
+/// - `Rejected`: tag=3, code(u8)
+/// - `Trade`: tag=4, aggressor(u64), resting(u64), price(i64), qty(i64), seq(u64)
+struct EventCodec;
+
+impl EventCodec {
+    fn encode(&self, event: &Event) -> EncodeResult {
+        let mut out = Vec::with_capacity(1 + 8 * 6);
+        match event {
+            Event::Accepted(oid) => {
+                out.push(1);
+                put_u64(&mut out, *oid);
+            }
+            Event::Canceled(oid) => {
+                out.push(2);
+                put_u64(&mut out, *oid);
+            }
+            Event::Rejected(rej) => {
+                out.push(3);
+                out.push(rejection_code(*rej));
+            }
+            Event::Trade(t) => {
+                out.push(4);
+                put_u64(&mut out, t.aggressor);
+                put_u64(&mut out, t.resting);
+                put_i64(&mut out, t.price);
+                put_i64(&mut out, t.quantity);
+                put_u64(&mut out, t.sequence);
+            }
+        }
+        Ok(out)
+    }
+}
+
+fn rejection_code(r: RejectionError) -> u8 {
+    // Stable mapping for measurement payloads (not a public protocol guarantee).
+    match r {
+        RejectionError::InvalidPrice => 1,
+        RejectionError::InvalidQuantity => 2,
+        RejectionError::SelfTrade => 3,
+        RejectionError::OrderNotFound(_) => 4,
+        RejectionError::StaleSequence => 5,
+        RejectionError::ParticipantMismatch => 6,
+        RejectionError::PriceBookInvariantViolation => 7,
+        RejectionError::InsufficientLiquidity => 8,
+        RejectionError::SymbolDuplicate => 9,
+        RejectionError::SymbolNotFound => 10,
+        RejectionError::OrderBookDuplicate => 11,
+        RejectionError::OrderBookNotFound => 12,
+        RejectionError::OrderDuplicate => 13,
+        RejectionError::OrderIdInvalid => 14,
+        RejectionError::OrderTypeInvalid => 15,
+        RejectionError::OrderParameterInvalid => 16,
+        RejectionError::OrderQuantityInvalid => 17,
+    }
+}
+
+fn put_u64(buf: &mut Vec<u8>, v: u64) {
+    buf.extend_from_slice(&v.to_le_bytes());
+}
+
+fn put_i64(buf: &mut Vec<u8>, v: i64) {
+    buf.extend_from_slice(&v.to_le_bytes());
+}

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -8,6 +8,9 @@ use crate::{
     types::{OrderId, Trade},
 };
 
+mod bytes_channel;
+pub use bytes_channel::BytesChannelEventSink;
+
 /// Event sink that discards all events (e.g. for ingestion tests).
 #[derive(Debug, Clone, Default)]
 pub struct NoOpEventSink;


### PR DESCRIPTION
## Summary
Adds a **production-ish** harness mode where engine events are **serialized to bytes** and pushed through a **bounded channel** (backpressure), then drained by a background consumer.

This directly supports publishing numbers that include event-publishing overhead, instead of only `NoOpEventSink`.

## Changes
- `events::BytesChannelEventSink`: stable compact binary encoding + `try_send` into bounded `crossbeam_channel`
- `server` flags:
  - `--event-sink {noop,bytes_channel}`
  - `--event-channel-capacity <N>`
  - `--order-store {hash_map,dense}`
- `server` constructs a drain thread when `bytes_channel` is selected
- README: includes measured op-target ladder rows for `BytesChannelEventSink` (4 clients, random load)

## Notes
- `DenseOrderStore` is exposed for experiments; it is only appropriate when order ids are bounded/dense.
- Matcher remains a concrete `enum` (no trait-object dispatch on the matcher hot path).

## Validation
- `make ci`
- `make quality-gate`
